### PR TITLE
feat: CREATEMONITOR 命令等待 CCD 就绪后再回复管道

### DIFF
--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -1581,29 +1581,43 @@ void HandleClient(HANDLE hPipe)
 			vddlog("p", "Heartbeat Ping");
 		};
 
-		auto handleCreateMonitor = [](HANDLE, wchar_t *param)
+		auto handleCreateMonitor = [](HANDLE hPipe, wchar_t *param)
 		{
+			auto writePipeResponse = [&](const char *resp)
+			{
+				if (hPipe != INVALID_HANDLE_VALUE)
+				{
+					DWORD bytesWritten;
+					WriteFile(hPipe, resp, static_cast<DWORD>(strlen(resp)), &bytesWritten, NULL);
+				}
+			};
+
 			if (g_GlobalDevice == nullptr)
 			{
 				vddlog("e", "Global device not initialized");
+				writePipeResponse("FAIL");
 				return;
 			}
 
-			lock_guard<mutex> lock(g_Mutex);
-			auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
-			if (!pContext || !pContext->pContext)
+			bool has_monitors = false;
 			{
-				vddlog("e", "Failed to get device context for monitor creation");
-				return;
-			}
+				lock_guard<mutex> lock(g_Mutex);
+				auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
+				if (!pContext || !pContext->pContext)
+				{
+					vddlog("e", "Failed to get device context for monitor creation");
+					writePipeResponse("FAIL");
+					return;
+				}
 
-			if (numVirtualDisplays == 0)
-			{
-				vddlog("e", "Invalid display count: 0");
-				return;
-			}
+				if (numVirtualDisplays == 0)
+				{
+					vddlog("e", "Invalid display count: 0");
+					writePipeResponse("FAIL");
+					return;
+				}
 
-			vddlog("i", "Starting monitor creation");
+				vddlog("i", "Starting monitor creation");
 
 			// Parse GUID and HDR luminance settings from parameter
 			// Format: "{GUID}:[maxNits,minNits,maxFALL][widthCm,heightCm]" or multiple space-separated entries
@@ -1743,6 +1757,82 @@ void HandleClient(HANDLE hPipe)
 					heightCm = mp.heightCm;
 				}
 				pContext->pContext->CreateMonitor(i, pGuid, maxNits, minNits, maxFALL, widthCm, heightCm);
+			}
+
+			// Check if any monitors were actually created before waiting for CCD
+			has_monitors = pContext->pContext->HasActiveMonitor();
+			} // release g_Mutex before CCD wait
+
+			if (!has_monitors)
+			{
+				vddlog("e", "No monitors were created, skipping CCD wait");
+				writePipeResponse("FAIL");
+				return;
+			}
+
+			// Wait for CCD system to recognize the new monitor before responding
+			// This prevents Sunshine from having to poll/retry after creation
+			constexpr int CCD_WAIT_MAX_MS = 15000;
+			constexpr int CCD_WAIT_INTERVAL_MS = 200;
+			bool ccd_ready = false;
+
+			vddlog("i", "Waiting for CCD system to recognize new monitor...");
+
+			for (int elapsed = 0; elapsed < CCD_WAIT_MAX_MS; elapsed += CCD_WAIT_INTERVAL_MS)
+			{
+				UINT32 pathCount = 0, modeCount = 0;
+				LONG result = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount, &modeCount);
+
+				if (result == ERROR_SUCCESS && pathCount > 0)
+				{
+					std::vector<DISPLAYCONFIG_PATH_INFO> paths(pathCount);
+					std::vector<DISPLAYCONFIG_MODE_INFO> modes(modeCount);
+					result = QueryDisplayConfig(
+						QDC_ONLY_ACTIVE_PATHS,
+						&pathCount, paths.data(),
+						&modeCount, modes.data(), nullptr);
+
+					if (result == ERROR_SUCCESS)
+					{
+						for (UINT32 j = 0; j < pathCount; j++)
+						{
+							DISPLAYCONFIG_TARGET_DEVICE_NAME targetName = {};
+							targetName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+							targetName.header.size = sizeof(targetName);
+							targetName.header.adapterId = paths[j].targetInfo.adapterId;
+							targetName.header.id = paths[j].targetInfo.id;
+
+							if (DisplayConfigGetDeviceInfo(&targetName.header) == ERROR_SUCCESS)
+							{
+								if (wcscmp(targetName.monitorFriendlyDeviceName, L"Zako HDR") == 0)
+								{
+									ccd_ready = true;
+									break;
+								}
+							}
+						}
+					}
+				}
+
+				if (ccd_ready)
+				{
+					stringstream ss;
+					ss << "CCD recognized VDD monitor after " << elapsed << "ms";
+					vddlog("i", ss.str().c_str());
+					break;
+				}
+
+				Sleep(CCD_WAIT_INTERVAL_MS);
+			}
+
+			if (ccd_ready)
+			{
+				writePipeResponse("OK");
+			}
+			else
+			{
+				vddlog("w", "CCD did not recognize VDD monitor within timeout");
+				writePipeResponse("OK_PENDING");
 			}
 		};
 

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -42,6 +42,7 @@ Environment:
 #include <atomic>
 
 #define PIPE_NAME L"\\\\.\\pipe\\ZakoVDDPipe"
+#define VDD_MONITOR_NAME L"Zako HDR"
 
 #pragma comment(lib, "xmllite.lib")
 #pragma comment(lib, "shlwapi.lib")
@@ -1804,7 +1805,7 @@ void HandleClient(HANDLE hPipe)
 
 							if (DisplayConfigGetDeviceInfo(&targetName.header) == ERROR_SUCCESS)
 							{
-								if (wcscmp(targetName.monitorFriendlyDeviceName, L"Zako HDR") == 0)
+								if (wcscmp(targetName.monitorFriendlyDeviceName, VDD_MONITOR_NAME) == 0)
 								{
 									ccd_ready = true;
 									break;


### PR DESCRIPTION
### 问题

当 Sunshine 通过管道发送 `CREATEMONITOR` 命令时，驱动调用 `IddCxMonitorCreate` + `IddCxMonitorArrival` 后**不回复任何响应**。Sunshine 端管道读取 3 秒超时后，开始轮询 `QueryDisplayConfig` 检测新设备。

在无头主机上，Windows CCD 子系统需要较长时间才能注册新的虚拟显示器（`QueryDisplayConfig` 返回 `ERROR_INVALID_PARAMETER`），导致 Sunshine 必须多次执行 disable/enable + 重建循环，总耗时约 10 秒以上。

### 修改

`handleCreateMonitor` 管道命令处理：

1. **添加管道响应**：所有路径（成功/失败）现在都会写响应到管道
2. **CCD 就绪等待**：创建 monitor 后，在释放 `g_Mutex` 锁后轮询 `QueryDisplayConfig` 检测 "Zako HDR" 设备，每 200ms 检查一次，最多等 15 秒
3. **创建失败快速返回**：通过 `HasActiveMonitor()` 检查创建是否成功，失败时立即回复 `FAIL`，不进入等待循环
4. **锁范围缩小**：`g_Mutex` 只覆盖 `CreateMonitor()` 调用，CCD 等待在锁外执行

### 管道协议变更

| 响应 | 含义 |
|---|---|
| `OK` | 创建成功且 CCD 已识别设备 |
| `OK_PENDING` | 创建成功但 CCD 15 秒内未就绪 |
| `FAIL` | 创建失败（设备初始化错误/上下文无效等） |
| _(无响应/超时)_ | 旧版驱动行为，保持向后兼容 |

### 效果

- 正常情况：CCD 就绪后立即回复 `OK`，Sunshine 无需轮询
- 极端情况（15s 超时）：回复 `OK_PENDING`，Sunshine 回退到原有等待逻辑
- 创建失败：立即回复 `FAIL`，Sunshine 秒级进入重试，不浪费时间等待


