### PR TITLE
fix: use IddCx INIT macros for struct Size fields to fix Win10 compatibility

### DIFF
--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -3727,7 +3727,7 @@ void IndirectDeviceContext::InitAdapter()
 	logStream.str("");
 
 	IDDCX_ADAPTER_CAPS AdapterCaps = {};
-	AdapterCaps.Size = sizeof(AdapterCaps);
+	IDDCX_ADAPTER_CAPS_INIT(&AdapterCaps);
 
 	if (IDD_IS_FUNCTION_AVAILABLE(IddCxSwapChainReleaseAndAcquireBuffer2))
 	{
@@ -3746,7 +3746,7 @@ void IndirectDeviceContext::InitAdapter()
 
 	// Declare basic feature support for the adapter (required)
 	AdapterCaps.MaxMonitorsSupported = numVirtualDisplays;
-	AdapterCaps.EndPointDiagnostics.Size = sizeof(AdapterCaps.EndPointDiagnostics);
+	IDDCX_ENDPOINT_DIAGNOSTIC_INFO_INIT(&AdapterCaps.EndPointDiagnostics);
 	AdapterCaps.EndPointDiagnostics.GammaSupport = IDDCX_FEATURE_IMPLEMENTATION_NONE;
 	AdapterCaps.EndPointDiagnostics.TransmissionType = IDDCX_TRANSMISSION_TYPE_WIRED_OTHER;
 
@@ -3757,7 +3757,7 @@ void IndirectDeviceContext::InitAdapter()
 
 	// Declare your hardware and firmware versions (required)
 	IDDCX_ENDPOINT_VERSION Version = {};
-	Version.Size = sizeof(Version);
+	IDDCX_ENDPOINT_VERSION_INIT(&Version);
 	Version.MajorVer = 1;
 	AdapterCaps.EndPointDiagnostics.pFirmwareVersion = &Version;
 	AdapterCaps.EndPointDiagnostics.pHardwareVersion = &Version;
@@ -3959,7 +3959,7 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 	}
 
 	IDDCX_MONITOR_INFO MonitorInfo = {};
-	MonitorInfo.Size = sizeof(MonitorInfo);
+	IDDCX_MONITOR_INFO_INIT(&MonitorInfo);
 	MonitorInfo.MonitorType = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI;
 	MonitorInfo.ConnectorIndex = index;
 	MonitorInfo.MonitorDescription.Size = sizeof(MonitorInfo.MonitorDescription);
@@ -4259,7 +4259,7 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 			m_MouseEvents[Monitor] = hMouseEvent;
 
 			IDDCX_CURSOR_CAPS cursorInfo = {};
-			cursorInfo.Size = sizeof(cursorInfo);
+			IDDCX_CURSOR_CAPS_INIT(&cursorInfo);
 			cursorInfo.ColorXorCursorSupport = IDDCX_XOR_CURSOR_SUPPORT_FULL;
 			cursorInfo.AlphaCursorSupport = alphaCursorSupport;
 
@@ -4461,7 +4461,7 @@ _Use_decl_annotations_
 		// Copy the known modes to the output buffer
 		for (DWORD ModeIndex = 0; ModeIndex < localModes.size(); ModeIndex++)
 		{
-			pInArgs->pMonitorModes[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE);
+			IDDCX_MONITOR_MODE_INIT(&pInArgs->pMonitorModes[ModeIndex]);
 			pInArgs->pMonitorModes[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
 			pInArgs->pMonitorModes[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
 		}
@@ -4529,7 +4529,7 @@ void CreateTargetMode(DISPLAYCONFIG_VIDEO_SIGNAL_INFO &Mode, UINT Width, UINT He
 
 void CreateTargetMode(IDDCX_TARGET_MODE &Mode, UINT Width, UINT Height, UINT VSyncNum, UINT VSyncDen)
 {
-	Mode.Size = sizeof(Mode);
+	IDDCX_TARGET_MODE_INIT(&Mode);
 	CreateTargetMode(Mode.TargetVideoSignalInfo.targetVideoSignalInfo, Width, Height, VSyncNum, VSyncDen);
 }
 
@@ -4542,7 +4542,7 @@ void CreateTargetMode2(IDDCX_TARGET_MODE2 &Mode, UINT Width, UINT Height, UINT V
 			  << ", VSyncDen: " << VSyncDen;
 	vddlog("d", logStream.str().c_str());
 
-	Mode.Size = sizeof(Mode);
+	IDDCX_TARGET_MODE2_INIT(&Mode);
 
 	if (ColourFormat == L"RGB")
 	{
@@ -4809,7 +4809,7 @@ _Use_decl_annotations_
 		logStream << "Writing monitor modes to output buffer:";
 		for (DWORD ModeIndex = 0; ModeIndex < localModes.size(); ModeIndex++)
 		{
-			pInArgs->pMonitorModes[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE2);
+			IDDCX_MONITOR_MODE2_INIT(&pInArgs->pMonitorModes[ModeIndex]);
 			pInArgs->pMonitorModes[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
 			pInArgs->pMonitorModes[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
 


### PR DESCRIPTION
The driver is compiled against IddCx 1.10 headers but needs to run on Win10 (IddCx 1.5). Using sizeof() for struct Size fields produces the IddCx 1.10 struct size, which is larger than what Win10's IddCx 1.5 runtime expects, causing IddCxMonitorCreate to fail with 0xC0000476.

Replace sizeof() with proper IDDCX_*_INIT() macros which set the Size field based on IDDCX_MINIMUM_VERSION_REQUIRED (1.3), ensuring backward compatibility with older IddCx runtimes.
