### PR TITLE
fix(vdd): reload runtime settings before adapter reinit

### DIFF
--- a/Community Scripts/get_disp_num.ps1
+++ b/Community Scripts/get_disp_num.ps1
@@ -1,1 +1,1 @@
-Get-Monitor | Where-Object { $_.InstanceName -like '*MTT1337*' } | Sort-Object { [int] (($_.InstanceName -match 'UID(\d+)') -and $Matches[1]) } | Select-Object -First 1 -ExpandProperty LogicalDisplay | select-object Devicename
+Get-Monitor | Where-Object { $_.InstanceName -like '*ZAK2333*' } | Sort-Object { [int] (($_.InstanceName -match 'UID(\d+)') -and $Matches[1]) } | Select-Object -First 1 -ExpandProperty LogicalDisplay | select-object Devicename

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -4172,10 +4172,12 @@ void modifyEdid(vector<BYTE> &edid)
 		return;
 	}
 
-	edid[8] = 0x36;
-	edid[9] = 0x94;
-	edid[10] = 0x37;
-	edid[11] = 0x13;
+	// EDID manufacturer/product ID exposed by Windows as DISPLAY\ZAK2333.
+	// Manufacturer "ZAK" is encoded as 0x682b; product 0x2333 is little-endian.
+	edid[8] = 0x68;
+	edid[9] = 0x2b;
+	edid[10] = 0x33;
+	edid[11] = 0x23;
 }
 
 // Modify EDID serial number based on client GUID to ensure consistency

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -1532,6 +1532,8 @@ void logAvailableGPUs()
 	}
 }
 
+void LoadDriverSettings();
+
 void ReloadDriver(HANDLE hPipe)
 {
 	UNREFERENCED_PARAMETER(hPipe);
@@ -1574,6 +1576,7 @@ void ReloadDriver(HANDLE hPipe)
 
 				// Step 4: Reinitialize the adapter (this will reload XML configuration)
 				vddlog("d", "Reinitializing adapter with new configuration");
+				LoadDriverSettings();
 				pContext->pContext->InitAdapter();
 
 				// Step 5: Post-initialization stabilization
@@ -1591,6 +1594,7 @@ void ReloadDriver(HANDLE hPipe)
 				// Try to continue with initialization anyway
 				try
 				{
+					LoadDriverSettings();
 					pContext->pContext->InitAdapter();
 					vddlog("w", "Adapter reinitialized after exception");
 				}
@@ -1606,6 +1610,7 @@ void ReloadDriver(HANDLE hPipe)
 				// Try to continue with initialization anyway
 				try
 				{
+					LoadDriverSettings();
 					pContext->pContext->InitAdapter();
 					vddlog("w", "Adapter reinitialized after unknown exception");
 				}
@@ -2453,6 +2458,62 @@ bool initpath()
 	return true;
 }
 
+// Keep the in-memory runtime knobs in sync with registry/XML settings.
+// DriverEntry calls this once at process startup, while RELOAD_DRIVER and
+// toggle commands call it before recreating monitors so changes such as
+// HARDWARECURSOR true affect the next swapchain without requiring an adapter
+// disable/enable cycle.
+void LoadDriverSettings()
+{
+	initpath();
+	logsEnabled = EnabledQuery(L"LoggingEnabled");
+	debugLogs = EnabledQuery(L"DebugLoggingEnabled");
+
+	customEdid = EnabledQuery(L"CustomEdidEnabled");
+	preventManufacturerSpoof = EnabledQuery(L"PreventMonitorSpoof");
+	edidCeaOverride = EnabledQuery(L"EdidCeaOverride");
+	// [LEGACY-PIPE]
+	sendLogsThroughPipe = EnabledQuery(L"SendLogsThroughPipe");
+
+	// colour
+	HDRPlus = EnabledQuery(L"HDRPlusEnabled");
+	SDR10 = EnabledQuery(L"SDR10Enabled");
+	HDRCOLOUR = HDRPlus ? IDDCX_BITS_PER_COMPONENT_12 : IDDCX_BITS_PER_COMPONENT_10;
+	SDRCOLOUR = SDR10 ? IDDCX_BITS_PER_COMPONENT_10 : IDDCX_BITS_PER_COMPONENT_8;
+	ColourFormat = GetStringSetting(L"ColourFormat");
+
+	// EDID profile: Auto -> resolved via host OS build number (issue #612).
+	ApplyEdidProfileSetting(GetStringSetting(L"EdidProfile"));
+
+	// VRR / FreeSync: behavioural change, default OFF until EDID FreeSync
+	// Range Block also lands (see ROADMAP P1).
+	vrrEnabled = EnabledQuery(L"VrrEnabled");
+
+	// Cursor
+	hardwareCursor = EnabledQuery(L"HardwareCursorEnabled");
+	alphaCursorSupport = EnabledQuery(L"AlphaCursorSupport");
+	CursorMaxX = GetIntegerSetting(L"CursorMaxX");
+	CursorMaxY = GetIntegerSetting(L"CursorMaxY");
+
+	int xorCursorSupportLevelInt = GetIntegerSetting(L"XorCursorSupportLevel");
+	std::string xorCursorSupportLevelName;
+
+	if (xorCursorSupportLevelInt < 0 || xorCursorSupportLevelInt > 3)
+	{
+		vddlog("w", "Selected Xor Level unsupported, defaulting to IDDCX_XOR_CURSOR_SUPPORT_FULL");
+		XorCursorSupportLevel = IDDCX_XOR_CURSOR_SUPPORT_FULL;
+	}
+	else
+	{
+		XorCursorSupportLevel = static_cast<IDDCX_XOR_CURSOR_SUPPORT>(xorCursorSupportLevelInt);
+	}
+
+	xorCursorSupportLevelName = XorCursorSupportLevelToString(XorCursorSupportLevel);
+
+	vddlog("i", ("Selected Xor Cursor Support Level: " + xorCursorSupportLevelName).c_str());
+	vddlog("i", (std::string("Hardware cursor runtime setting: ") + (hardwareCursor ? "enabled" : "disabled")).c_str());
+}
+
 extern "C" EVT_WDF_DRIVER_UNLOAD EvtDriverUnload;
 
 VOID EvtDriverUnload(
@@ -2532,52 +2593,7 @@ _Use_decl_annotations_ extern "C" NTSTATUS DriverEntry(
 	WDF_DRIVER_CONFIG_INIT(&Config, VirtualDisplayDriverDeviceAdd);
 
 	Config.EvtDriverUnload = EvtDriverUnload;
-	initpath();
-	logsEnabled = EnabledQuery(L"LoggingEnabled");
-	debugLogs = EnabledQuery(L"DebugLoggingEnabled");
-
-	customEdid = EnabledQuery(L"CustomEdidEnabled");
-	preventManufacturerSpoof = EnabledQuery(L"PreventMonitorSpoof");
-	edidCeaOverride = EnabledQuery(L"EdidCeaOverride");
-	// [LEGACY-PIPE]
-	sendLogsThroughPipe = EnabledQuery(L"SendLogsThroughPipe");
-
-	// colour
-	HDRPlus = EnabledQuery(L"HDRPlusEnabled");
-	SDR10 = EnabledQuery(L"SDR10Enabled");
-	HDRCOLOUR = HDRPlus ? IDDCX_BITS_PER_COMPONENT_12 : IDDCX_BITS_PER_COMPONENT_10;
-	SDRCOLOUR = SDR10 ? IDDCX_BITS_PER_COMPONENT_10 : IDDCX_BITS_PER_COMPONENT_8;
-	ColourFormat = GetStringSetting(L"ColourFormat");
-
-	// EDID profile: Auto -> resolved via host OS build number (issue #612).
-	ApplyEdidProfileSetting(GetStringSetting(L"EdidProfile"));
-
-	// VRR / FreeSync: behavioural change, default OFF until EDID FreeSync
-	// Range Block also lands (see ROADMAP P1).
-	vrrEnabled = EnabledQuery(L"VrrEnabled");
-
-	// Cursor
-	hardwareCursor = EnabledQuery(L"HardwareCursorEnabled");
-	alphaCursorSupport = EnabledQuery(L"AlphaCursorSupport");
-	CursorMaxX = GetIntegerSetting(L"CursorMaxX");
-	CursorMaxY = GetIntegerSetting(L"CursorMaxY");
-
-	int xorCursorSupportLevelInt = GetIntegerSetting(L"XorCursorSupportLevel");
-	std::string xorCursorSupportLevelName;
-
-	if (xorCursorSupportLevelInt < 0 || xorCursorSupportLevelInt > 3)
-	{
-		vddlog("w", "Selected Xor Level unsupported, defaulting to IDDCX_XOR_CURSOR_SUPPORT_FULL");
-		XorCursorSupportLevel = IDDCX_XOR_CURSOR_SUPPORT_FULL;
-	}
-	else
-	{
-		XorCursorSupportLevel = static_cast<IDDCX_XOR_CURSOR_SUPPORT>(xorCursorSupportLevelInt);
-	}
-
-	xorCursorSupportLevelName = XorCursorSupportLevelToString(XorCursorSupportLevel);
-
-	vddlog("i", ("Selected Xor Cursor Support Level: " + xorCursorSupportLevelName).c_str());
+	LoadDriverSettings();
 
 	vddlog("i", "Driver Starting");
 	string utf8_confpath = WStringToString(confpath);


### PR DESCRIPTION
## Summary

Refresh the driver's in-memory runtime settings before reinitializing the adapter during `RELOAD_DRIVER` and toggle-command flows.

Also brand the spoofed monitor EDID hardware ID as `DISPLAY\ZAK2333` instead of the upstream `DISPLAY\MTT1337` by changing the EDID manufacturer/product bytes to `ZAK` + `0x2333`.

## Why

`HARDWARECURSOR true` updated `vdd_settings.xml`, but the driver only populated `hardwareCursor` during `DriverEntry`. A reload could recreate monitors and swapchains using the stale in-memory value, so hardware cursor setup was skipped until an adapter-level restart.

Using a project-specific monitor hardware ID also avoids carrying the old `MTT1337` identity in Windows monitor instance paths.

## Validation

- Built `Release|x64` with MSBuild using `SkipPackageVerification=true` because the local WDK install is missing `x86\InfVerif.dll`.
- `ApiValidator`: driver is Universal.
- `inf2cat`: signability test passed with 0 errors / 0 warnings.
- Latest build after `ZAK2333` change: 0 errors / 11 existing Code Analysis warnings.
- Earlier local install validation on this branch: `oem113.inf`, version `13.58.19.371`.
- ETW confirmed runtime behavior:
  - `Hardware cursor runtime setting: enabled`
  - `Hardware cursor setup completed successfully.`
- Final PnP state after recovery: Zako adapter and `Generic Monitor (Zako HDR)` both `CM_PROB_NONE`.
