### PR TITLE
feat(vdd): export multi-slot shared frame ring

### DIFF
--- a/ZakoVDD/Rendering/SharedFrameExporter.cpp
+++ b/ZakoVDD/Rendering/SharedFrameExporter.cpp
@@ -12,6 +12,16 @@ namespace Microsoft
 namespace IndirectDisp
 {
 
+static std::wstring SharedTextureName(unsigned int monitorIndex, UINT slotIndex)
+{
+	std::wstring base = L"Global\\ZakoVDD_Frame_" + std::to_wstring(monitorIndex);
+	if (slotIndex == 0)
+	{
+		return base;
+	}
+	return base + L"_Slot_" + std::to_wstring(slotIndex);
+}
+
 struct SharedFrameMetadata
 {
 	UINT32 Magic;          // 'ZVDF' = 0x5A564446
@@ -33,6 +43,13 @@ struct SharedFrameMetadata
 	UINT64 ReplacedUnreadFrames;       // Producer overwrote a published frame before it was consumed
 	UINT64 DroppedConsumerHeldFrames;  // Consumer held the slot while producer wanted to publish
 	UINT64 DroppedAcquireFailures;     // Non-timeout keyed mutex acquire failures
+	UINT32 MetadataSize;               // sizeof(SharedFrameMetadata) for optional-tail readers
+	UINT32 SlotCount;                  // Number of shared mailbox slots exported by this producer
+	UINT32 SlotIndex;                  // Slot containing the latest published frame
+	UINT32 Reserved0;
+	UINT32 AdapterLuidLowPart;         // Render adapter LUID used by this swap chain
+	INT32  AdapterLuidHighPart;
+	UINT64 ProducerQpcFrequency;
 };
 
 SharedFrameExporter::SharedFrameExporter(unsigned int monitorIndex, std::shared_ptr<Direct3DDevice> device)
@@ -72,39 +89,88 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 	}
 
 	// Best-effort acquire with 0 timeout. First try the normal empty-slot
-	// key (0). If the previous frame is still published but unread (key 1),
-	// reclaim and overwrite it. That gives the export path WGC-like
-	// "latest frame wins" mailbox semantics without stalling the IddCx loop.
+	// key (0) across the ring. If all slots are already published but unread
+	// (key 1), reclaim one and overwrite it. That keeps WGC-like "latest frame
+	// wins" semantics without stalling the IddCx loop.
 	bool replacedUnreadFrame = false;
-	HRESULT hr = m_KeyedMutex->AcquireSync(0, 0);
-	if (hr == static_cast<HRESULT>(WAIT_TIMEOUT))
+	bool sawTimeout = false;
+	bool sawFailure = false;
+	UINT selectedSlot = SharedFrameSlotCount;
+	HRESULT hr = E_FAIL;
+
+	// IDXGIKeyedMutex::AcquireSync returns WAIT_TIMEOUT as a DWORD-style
+	// success code, so only S_OK means the mutex was actually acquired.
+	for (UINT offset = 0; offset < SharedFrameSlotCount; ++offset)
 	{
-		hr = m_KeyedMutex->AcquireSync(1, 0);
-		if (SUCCEEDED(hr))
+		UINT slot = (m_NextPublishSlot + offset) % SharedFrameSlotCount;
+		if (!m_KeyedMutex[slot])
 		{
-			replacedUnreadFrame = true;
+			continue;
+		}
+
+		hr = m_KeyedMutex[slot]->AcquireSync(0, 0);
+		if (hr == S_OK)
+		{
+			selectedSlot = slot;
+			break;
+		}
+		if (hr == static_cast<HRESULT>(WAIT_TIMEOUT))
+		{
+			sawTimeout = true;
+		}
+		else
+		{
+			sawFailure = true;
 		}
 	}
-	if (hr == static_cast<HRESULT>(WAIT_TIMEOUT))
+
+	if (selectedSlot == SharedFrameSlotCount)
+	{
+		for (UINT offset = 0; offset < SharedFrameSlotCount; ++offset)
+		{
+			UINT slot = (m_NextPublishSlot + offset) % SharedFrameSlotCount;
+			if (!m_KeyedMutex[slot])
+			{
+				continue;
+			}
+
+			hr = m_KeyedMutex[slot]->AcquireSync(1, 0);
+			if (hr == S_OK)
+			{
+				selectedSlot = slot;
+				replacedUnreadFrame = true;
+				break;
+			}
+			if (hr == static_cast<HRESULT>(WAIT_TIMEOUT))
+			{
+				sawTimeout = true;
+			}
+			else
+			{
+				sawFailure = true;
+			}
+		}
+	}
+
+	if (selectedSlot == SharedFrameSlotCount)
 	{
 		if (m_MetaView)
 		{
-			m_MetaView->DroppedConsumerHeldFrames++;
-		}
-		return;
-	}
-	if (FAILED(hr))
-	{
-		if (m_MetaView)
-		{
-			m_MetaView->DroppedAcquireFailures++;
+			if (sawTimeout)
+			{
+				m_MetaView->DroppedConsumerHeldFrames++;
+			}
+			else if (sawFailure)
+			{
+				m_MetaView->DroppedAcquireFailures++;
+			}
 		}
 		return;
 	}
 
 	Microsoft::WRL::ComPtr<ID3D11DeviceContext> ctx;
 	m_Device->Device->GetImmediateContext(&ctx);
-	ctx->CopyResource(m_SharedTex.Get(), srcTex.Get());
+	ctx->CopyResource(m_SharedTex[selectedSlot].Get(), srcTex.Get());
 	ctx->Flush();
 
 	// Update metadata before releasing key 1 so the consumer sees metadata
@@ -118,13 +184,24 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		m_MetaView->LastPublishQpc = static_cast<UINT64>(qpc.QuadPart);
 		m_MetaView->LastPresentationFrameNumber = presentationFrameNumber;
 		m_MetaView->LastDirtyRectCount = dirtyRectCount;
+		m_MetaView->SlotCount = SharedFrameSlotCount;
+		m_MetaView->SlotIndex = selectedSlot;
 		if (replacedUnreadFrame)
 		{
 			m_MetaView->ReplacedUnreadFrames++;
 		}
 	}
 
-	m_KeyedMutex->ReleaseSync(1);
+	hr = m_KeyedMutex[selectedSlot]->ReleaseSync(1);
+	if (FAILED(hr))
+	{
+		std::stringstream ss;
+		ss << "[VddExport] ReleaseSync(1) failed for slot=" << selectedSlot << ": 0x" << std::hex << hr;
+		VDD_LOG_ERROR(ss.str().c_str());
+		TeardownTexture();
+		return;
+	}
+	m_NextPublishSlot = (selectedSlot + 1) % SharedFrameSlotCount;
 
 	if (m_FrameReadyEvent)
 	{
@@ -191,7 +268,17 @@ DXGI_FORMAT SharedFrameExporter::GuessMetadataFormat() const
 
 bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc)
 {
-	if (m_SharedTex &&
+	bool allSlotsReady = true;
+	for (const auto& tex : m_SharedTex)
+	{
+		if (!tex)
+		{
+			allSlotsReady = false;
+			break;
+		}
+	}
+
+	if (allSlotsReady &&
 	    m_CachedWidth == srcDesc.Width &&
 	    m_CachedHeight == srcDesc.Height &&
 	    m_CachedFormat == srcDesc.Format)
@@ -226,59 +313,60 @@ bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDes
 	desc.MipLevels = 1;
 	desc.ArraySize = 1;
 
-	HRESULT hr = m_Device->Device->CreateTexture2D(&desc, nullptr, &m_SharedTex);
-	if (FAILED(hr))
+	for (UINT slot = 0; slot < SharedFrameSlotCount; ++slot)
 	{
-		std::stringstream ss;
-		ss << "[VddExport] CreateTexture2D failed: 0x" << std::hex << hr;
-		VDD_LOG_ERROR(ss.str().c_str());
-		LocalFree(sd);
-		return false;
-	}
+		HRESULT hr = m_Device->Device->CreateTexture2D(&desc, nullptr, &m_SharedTex[slot]);
+		if (FAILED(hr))
+		{
+			std::stringstream ss;
+			ss << "[VddExport] CreateTexture2D failed for slot=" << slot << ": 0x" << std::hex << hr;
+			VDD_LOG_ERROR(ss.str().c_str());
+			LocalFree(sd);
+			TeardownTexture();
+			return false;
+		}
 
-	Microsoft::WRL::ComPtr<IDXGIResource1> dxgiRes;
-	hr = m_SharedTex.As(&dxgiRes);
-	if (FAILED(hr))
-	{
-		VDD_LOG_ERROR("[VddExport] QueryInterface IDXGIResource1 failed");
-		m_SharedTex.Reset();
-		LocalFree(sd);
-		return false;
-	}
+		Microsoft::WRL::ComPtr<IDXGIResource1> dxgiRes;
+		hr = m_SharedTex[slot].As(&dxgiRes);
+		if (FAILED(hr))
+		{
+			VDD_LOG_ERROR("[VddExport] QueryInterface IDXGIResource1 failed");
+			LocalFree(sd);
+			TeardownTexture();
+			return false;
+		}
 
-	std::wstring texName = L"Global\\ZakoVDD_Frame_" + std::to_wstring(m_MonitorIndex);
-	HANDLE ntHandle = nullptr;
-	hr = dxgiRes->CreateSharedHandle(&sa, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, texName.c_str(), &ntHandle);
+		HANDLE ntHandle = nullptr;
+		auto texName = SharedTextureName(m_MonitorIndex, slot);
+		hr = dxgiRes->CreateSharedHandle(&sa, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, texName.c_str(), &ntHandle);
+		if (FAILED(hr))
+		{
+			std::stringstream ss;
+			ss << "[VddExport] CreateSharedHandle failed for slot=" << slot << ": 0x" << std::hex << hr;
+			VDD_LOG_ERROR(ss.str().c_str());
+			LocalFree(sd);
+			TeardownTexture();
+			return false;
+		}
+		// The NT handle MUST stay open for the named lookup to remain valid;
+		// closing it before consumers open will make OpenSharedResourceByName
+		// return E_INVALIDARG even though the texture is still alive in our process.
+		m_NtHandle[slot] = ntHandle;
+
+		hr = m_SharedTex[slot].As(&m_KeyedMutex[slot]);
+		if (FAILED(hr) || !m_KeyedMutex[slot])
+		{
+			VDD_LOG_ERROR("[VddExport] QueryInterface IDXGIKeyedMutex failed");
+			LocalFree(sd);
+			TeardownTexture();
+			return false;
+		}
+	}
 	LocalFree(sd);
-	if (FAILED(hr))
-	{
-		std::stringstream ss;
-		ss << "[VddExport] CreateSharedHandle failed: 0x" << std::hex << hr;
-		VDD_LOG_ERROR(ss.str().c_str());
-		m_SharedTex.Reset();
-		return false;
-	}
-	// The NT handle MUST stay open for the named lookup to remain valid;
-	// closing it before consumers open will make OpenSharedResourceByName
-	// return E_INVALIDARG even though the texture is still alive in our process.
-	if (m_NtHandle)
-	{
-		CloseHandle(m_NtHandle);
-	}
-	m_NtHandle = ntHandle;
-
-	hr = m_SharedTex.As(&m_KeyedMutex);
-	if (FAILED(hr) || !m_KeyedMutex)
-	{
-		VDD_LOG_ERROR("[VddExport] QueryInterface IDXGIKeyedMutex failed");
-		m_SharedTex.Reset();
-		return false;
-	}
 
 	if (!EnsureEventAndMetadata(srcDesc))
 	{
-		m_KeyedMutex.Reset();
-		m_SharedTex.Reset();
+		TeardownTexture();
 		return false;
 	}
 
@@ -289,7 +377,8 @@ bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDes
 	std::stringstream ss;
 	ss << "[VddExport] Shared texture ready monitor=" << m_MonitorIndex
 	   << " " << srcDesc.Width << "x" << srcDesc.Height
-	   << " fmt=" << srcDesc.Format;
+	   << " fmt=" << srcDesc.Format
+	   << " slots=" << SharedFrameSlotCount;
 	VDD_LOG_INFO(ss.str().c_str());
 	return true;
 }
@@ -339,15 +428,29 @@ bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& src
 		    MapViewOfFile(m_MetaMapping, FILE_MAP_WRITE, 0, 0, sizeof(SharedFrameMetadata)));
 		if (!m_MetaView)
 		{
+			std::stringstream ss;
+			ss << "[VddExport] MapViewOfFile failed: " << GetLastError();
+			VDD_LOG_ERROR(ss.str().c_str());
+			CloseHandle(m_MetaMapping);
+			m_MetaMapping = nullptr;
 			LocalFree(sd);
 			return false;
 		}
 		ZeroMemory(m_MetaView, sizeof(SharedFrameMetadata));
 		m_MetaView->Magic = 0x5A564446; // 'ZVDF'
 		m_MetaView->Version = 1;
+		m_MetaView->MetadataSize = sizeof(SharedFrameMetadata);
+		m_MetaView->SlotCount = SharedFrameSlotCount;
+		m_MetaView->SlotIndex = 0;
+		LARGE_INTEGER frequency{};
+		if (QueryPerformanceFrequency(&frequency))
+		{
+			m_MetaView->ProducerQpcFrequency = static_cast<UINT64>(frequency.QuadPart);
+		}
 	}
 	LocalFree(sd);
 
+	m_MetaView->MetadataSize = sizeof(SharedFrameMetadata);
 	m_MetaView->Width = srcDesc.Width;
 	m_MetaView->Height = srcDesc.Height;
 	m_MetaView->DxgiFormat = srcDesc.Format;
@@ -355,18 +458,35 @@ bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& src
 	m_MetaView->MaxNits = m_PendingMaxNits;
 	m_MetaView->MinNits = m_PendingMinNits;
 	m_MetaView->MaxFALL = m_PendingMaxFALL;
+	m_MetaView->SlotCount = SharedFrameSlotCount;
+	m_MetaView->SlotIndex = 0;
+	if (m_Device)
+	{
+		m_MetaView->AdapterLuidLowPart = m_Device->AdapterLuid.LowPart;
+		m_MetaView->AdapterLuidHighPart = m_Device->AdapterLuid.HighPart;
+	}
 	return true;
 }
 
 void SharedFrameExporter::TeardownTexture()
 {
-	m_KeyedMutex.Reset();
-	m_SharedTex.Reset();
-	if (m_NtHandle)
+	for (auto& keyedMutex : m_KeyedMutex)
 	{
-		CloseHandle(m_NtHandle);
-		m_NtHandle = nullptr;
+		keyedMutex.Reset();
 	}
+	for (auto& tex : m_SharedTex)
+	{
+		tex.Reset();
+	}
+	for (auto& handle : m_NtHandle)
+	{
+		if (handle)
+		{
+			CloseHandle(handle);
+			handle = nullptr;
+		}
+	}
+	m_NextPublishSlot = 0;
 	m_CachedWidth = 0;
 	m_CachedHeight = 0;
 	m_CachedFormat = DXGI_FORMAT_UNKNOWN;

--- a/ZakoVDD/Rendering/SharedFrameExporter.h
+++ b/ZakoVDD/Rendering/SharedFrameExporter.h
@@ -2,6 +2,7 @@
 
 #include "Direct3DDevice.h"
 
+#include <array>
 #include <memory>
 #include <mutex>
 
@@ -13,6 +14,8 @@ namespace IndirectDisp
 class SharedFrameExporter
 {
 public:
+	static constexpr UINT SharedFrameSlotCount = 3;
+
 	SharedFrameExporter(unsigned int monitorIndex, std::shared_ptr<Direct3DDevice> device);
 	~SharedFrameExporter();
 
@@ -32,13 +35,14 @@ private:
 
 	unsigned int m_MonitorIndex = 0;
 	std::shared_ptr<Direct3DDevice> m_Device;
-	Microsoft::WRL::ComPtr<ID3D11Texture2D> m_SharedTex;
-	Microsoft::WRL::ComPtr<IDXGIKeyedMutex> m_KeyedMutex;
+	std::array<Microsoft::WRL::ComPtr<ID3D11Texture2D>, SharedFrameSlotCount> m_SharedTex;
+	std::array<Microsoft::WRL::ComPtr<IDXGIKeyedMutex>, SharedFrameSlotCount> m_KeyedMutex;
+	std::array<HANDLE, SharedFrameSlotCount> m_NtHandle = {};
 	std::mutex m_ExportMutex;
-	HANDLE m_NtHandle = nullptr;
 	HANDLE m_FrameReadyEvent = nullptr;
 	HANDLE m_MetaMapping = nullptr;
 	struct SharedFrameMetadata* m_MetaView = nullptr;
+	UINT m_NextPublishSlot = 0;
 
 	UINT m_CachedWidth = 0;
 	UINT m_CachedHeight = 0;

--- a/tools/vdd_capture_test/vdd_capture_test.cpp
+++ b/tools/vdd_capture_test/vdd_capture_test.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <chrono>
@@ -48,6 +49,19 @@ struct SharedFrameMetadata
     float  MaxFALL;
     UINT64 FrameCounter;
     UINT64 LastPresentQpc;
+    UINT64 LastPublishQpc;
+    UINT32 LastPresentationFrameNumber;
+    UINT32 LastDirtyRectCount;
+    UINT64 ReplacedUnreadFrames;
+    UINT64 DroppedConsumerHeldFrames;
+    UINT64 DroppedAcquireFailures;
+    UINT32 MetadataSize;
+    UINT32 SlotCount;
+    UINT32 SlotIndex;
+    UINT32 Reserved0;
+    UINT32 AdapterLuidLowPart;
+    INT32  AdapterLuidHighPart;
+    UINT64 ProducerQpcFrequency;
 };
 
 struct Args
@@ -94,6 +108,25 @@ static const char* DxgiFormatName(DXGI_FORMAT f)
     }
 }
 
+static std::wstring TextureName(unsigned int monitor, UINT32 slot)
+{
+    std::wstring base = L"Global\\ZakoVDD_Frame_" + std::to_wstring(monitor);
+    if (slot == 0) return base;
+    return base + L"_Slot_" + std::to_wstring(slot);
+}
+
+static bool HasProducerLuid(const SharedFrameMetadata* meta)
+{
+    return meta && (meta->AdapterLuidLowPart != 0 || meta->AdapterLuidHighPart != 0);
+}
+
+static bool AdapterMatchesProducer(const DXGI_ADAPTER_DESC1& adapter, const SharedFrameMetadata* meta)
+{
+    if (!HasProducerLuid(meta)) return true;
+    return adapter.AdapterLuid.LowPart == meta->AdapterLuidLowPart &&
+           adapter.AdapterLuid.HighPart == meta->AdapterLuidHighPart;
+}
+
 // Dump as PPM (P6) for quick visual sanity check (only handles BGRA8/RGBA8).
 static bool DumpPpm(const std::string& path, const uint8_t* bgra,
                     UINT width, UINT height, UINT rowPitch, bool isBgr)
@@ -136,7 +169,6 @@ int main(int argc, char** argv)
 
     std::wstring metaName  = L"Global\\ZakoVDD_Meta_"       + std::to_wstring(args.monitor);
     std::wstring evName    = L"Global\\ZakoVDD_FrameReady_" + std::to_wstring(args.monitor);
-    std::wstring texName   = L"Global\\ZakoVDD_Frame_"      + std::to_wstring(args.monitor);
 
     printf("[vdd_capture_test] monitor=%u frames=%d out=%s timeout=%ums\n",
            args.monitor, args.frames, args.out.c_str(), args.timeoutMs);
@@ -163,23 +195,33 @@ int main(int argc, char** argv)
         fprintf(stderr, "Bad metadata magic: 0x%08X (expected 0x5A564446)\n", meta->Magic);
         return 1;
     }
-    printf("[meta] %ux%u fmt=%s(%u) hdr=%u maxNits=%.1f frameCounter=%llu\n",
+    UINT32 slotCount = meta->SlotCount ? std::min<UINT32>(meta->SlotCount, 8) : 1;
+    printf("[meta] %ux%u fmt=%s(%u) hdr=%u maxNits=%.1f frameCounter=%llu slots=%u latestSlot=%u\n",
            meta->Width, meta->Height, DxgiFormatName((DXGI_FORMAT)meta->DxgiFormat),
            meta->DxgiFormat, meta->IsHdr, meta->MaxNits,
-           static_cast<unsigned long long>(meta->FrameCounter));
+           static_cast<unsigned long long>(meta->FrameCounter),
+           slotCount, meta->SlotIndex);
+    printf("[meta] dirtyRects=%u replacedUnread=%llu droppedConsumerHeld=%llu droppedAcquireFailures=%llu "
+           "presentFrame=%u qpcFreq=%llu adapterLuid=%08x:%08x\n",
+           meta->LastDirtyRectCount,
+           static_cast<unsigned long long>(meta->ReplacedUnreadFrames),
+           static_cast<unsigned long long>(meta->DroppedConsumerHeldFrames),
+           static_cast<unsigned long long>(meta->DroppedAcquireFailures),
+           meta->LastPresentationFrameNumber,
+           static_cast<unsigned long long>(meta->ProducerQpcFrequency),
+           static_cast<unsigned int>(meta->AdapterLuidHighPart),
+           meta->AdapterLuidLowPart);
 
     // Open frame-ready event
-    HANDLE hEvent = OpenEventW(SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, evName.c_str());
+    HANDLE hEvent = OpenEventW(SYNCHRONIZE, FALSE, evName.c_str());
     if (!hEvent)
     {
         fprintf(stderr, "OpenEventW(%ls) failed: %lu\n", evName.c_str(), GetLastError());
         return 1;
     }
 
-    // Enumerate all DXGI hardware adapters and try opening the shared texture
-    // on each. The producer-side D3D device is on a specific RenderAdapter
-    // assigned by IddCx; we have no way to know its LUID without extending the
-    // metadata, so brute-force across adapters until one succeeds.
+    // This tool requires the shared-ring metadata layout. Prefer the producer
+    // RenderAdapter LUID when present, then fall back to enumerating adapters.
     ComPtr<IDXGIFactory1> factory;
     HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory));
     if (FAILED(hr))
@@ -191,59 +233,87 @@ int main(int argc, char** argv)
     ComPtr<ID3D11Device> device;
     ComPtr<ID3D11DeviceContext> ctx;
     ComPtr<ID3D11Device1> device1;
-    ComPtr<ID3D11Texture2D> sharedTex;
+    std::vector<ComPtr<ID3D11Texture2D>> sharedTex;
     UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
 #ifdef _DEBUG
     flags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
     D3D_FEATURE_LEVEL fl = D3D_FEATURE_LEVEL_11_0;
+    const bool hasProducerLuid = HasProducerLuid(meta);
+    bool openedByProducerLuid = false;
 
-    for (UINT i = 0;; ++i)
+    for (int pass = 0; pass < (hasProducerLuid ? 2 : 1) && sharedTex.empty(); ++pass)
     {
-        ComPtr<IDXGIAdapter1> adapter;
-        if (factory->EnumAdapters1(i, &adapter) == DXGI_ERROR_NOT_FOUND) break;
-        DXGI_ADAPTER_DESC1 ad{};
-        adapter->GetDesc1(&ad);
-        if (ad.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) continue;
-        wprintf(L"[adapter %u] %ls LUID=%lx:%lx\n", i, ad.Description, ad.AdapterLuid.HighPart, ad.AdapterLuid.LowPart);
-
-        device.Reset(); ctx.Reset(); device1.Reset(); sharedTex.Reset();
-        hr = D3D11CreateDevice(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, flags,
-                               nullptr, 0, D3D11_SDK_VERSION,
-                               &device, &fl, &ctx);
-        if (FAILED(hr)) { fprintf(stderr, "  D3D11CreateDevice failed: 0x%08X\n", hr); continue; }
-        if (FAILED(device.As(&device1)) || !device1) continue;
-
-        hr = device1->OpenSharedResourceByName(texName.c_str(),
-                                               DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
-                                               IID_PPV_ARGS(&sharedTex));
-        if (SUCCEEDED(hr) && sharedTex)
+        for (UINT i = 0;; ++i)
         {
-            wprintf(L"  OpenSharedResourceByName OK on adapter %u\n", i);
-            break;
+            ComPtr<IDXGIAdapter1> adapter;
+            if (factory->EnumAdapters1(i, &adapter) == DXGI_ERROR_NOT_FOUND) break;
+            DXGI_ADAPTER_DESC1 ad{};
+            adapter->GetDesc1(&ad);
+            if (ad.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) continue;
+
+            const bool matchesProducer = AdapterMatchesProducer(ad, meta);
+            if (hasProducerLuid && pass == 0 && !matchesProducer) continue;
+            if (hasProducerLuid && pass == 1 && matchesProducer) continue;
+
+            wprintf(L"[adapter %u] %ls LUID=%lx:%lx%s\n", i, ad.Description,
+                    ad.AdapterLuid.HighPart, ad.AdapterLuid.LowPart,
+                    (hasProducerLuid && matchesProducer) ? L" producer" : L"");
+
+            device.Reset(); ctx.Reset(); device1.Reset(); sharedTex.clear();
+            hr = D3D11CreateDevice(adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, flags,
+                                   nullptr, 0, D3D11_SDK_VERSION,
+                                   &device, &fl, &ctx);
+            if (FAILED(hr)) { fprintf(stderr, "  D3D11CreateDevice failed: 0x%08X\n", hr); continue; }
+            if (FAILED(device.As(&device1)) || !device1) continue;
+
+            std::vector<ComPtr<ID3D11Texture2D>> opened(slotCount);
+            bool allOpened = true;
+            for (UINT32 slot = 0; slot < slotCount; ++slot)
+            {
+                auto texName = TextureName(args.monitor, slot);
+                hr = device1->OpenSharedResourceByName(texName.c_str(),
+                                                       DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+                                                       IID_PPV_ARGS(&opened[slot]));
+                if (FAILED(hr) || !opened[slot])
+                {
+                    fprintf(stderr, "  OpenSharedResourceByName(%u) failed: 0x%08X\n", slot, hr);
+                    allOpened = false;
+                    break;
+                }
+            }
+            if (allOpened)
+            {
+                sharedTex = std::move(opened);
+                openedByProducerLuid = hasProducerLuid && matchesProducer;
+                wprintf(L"  OpenSharedResourceByName OK on adapter %u (%u slots)%s\n",
+                        i, slotCount, openedByProducerLuid ? L" via producer LUID" : L"");
+                break;
+            }
         }
-        fprintf(stderr, "  OpenSharedResourceByName failed: 0x%08X\n", hr);
-        sharedTex.Reset();
     }
 
-    if (!sharedTex)
+    if (sharedTex.empty())
     {
-        fprintf(stderr, "FATAL: no adapter could open %ls\n", texName.c_str());
+        fprintf(stderr, "FATAL: no adapter could open VDD shared textures\n");
         return 1;
     }
 
-    ComPtr<IDXGIKeyedMutex> mutex;
-    if (FAILED(sharedTex.As(&mutex)) || !mutex)
+    std::vector<ComPtr<IDXGIKeyedMutex>> mutexes(sharedTex.size());
+    for (UINT32 slot = 0; slot < sharedTex.size(); ++slot)
     {
-        fprintf(stderr, "QueryInterface IDXGIKeyedMutex failed\n");
-        return 1;
+        if (FAILED(sharedTex[slot].As(&mutexes[slot])) || !mutexes[slot])
+        {
+            fprintf(stderr, "QueryInterface IDXGIKeyedMutex failed for slot %u\n", slot);
+            return 1;
+        }
     }
 
     D3D11_TEXTURE2D_DESC desc{};
-    sharedTex->GetDesc(&desc);
-    printf("[shared] tex %ux%u fmt=%s(%u) bind=0x%X misc=0x%X\n",
+    sharedTex[0]->GetDesc(&desc);
+    printf("[shared] tex %ux%u fmt=%s(%u) bind=0x%X misc=0x%X slots=%zu\n",
            desc.Width, desc.Height, DxgiFormatName(desc.Format),
-           desc.Format, desc.BindFlags, desc.MiscFlags);
+           desc.Format, desc.BindFlags, desc.MiscFlags, sharedTex.size());
 
     // Create CPU-readable staging texture for download
     D3D11_TEXTURE2D_DESC stageDesc = desc;
@@ -280,23 +350,25 @@ int main(int argc, char** argv)
             break;
         }
 
-        // Acquire key 1 (producer released as 1)
-        hr = mutex->AcquireSync(1, args.timeoutMs);
+        UINT32 slot = meta->SlotIndex < mutexes.size() ? meta->SlotIndex : 0;
+
+        // AcquireSync returns WAIT_TIMEOUT directly; only S_OK means acquired.
+        hr = mutexes[slot]->AcquireSync(1, args.timeoutMs);
         if (hr == static_cast<HRESULT>(WAIT_TIMEOUT))
         {
-            fprintf(stderr, "[acquire] keyed mutex timeout; producer stuck?\n");
+            fprintf(stderr, "[acquire] keyed mutex timeout on slot %u; producer stuck?\n", slot);
             continue;
         }
         if (FAILED(hr))
         {
-            fprintf(stderr, "AcquireSync failed: 0x%08X\n", hr);
+            fprintf(stderr, "AcquireSync(slot %u) failed: 0x%08X\n", slot, hr);
             break;
         }
 
-        ctx->CopyResource(stage.Get(), sharedTex.Get());
+        ctx->CopyResource(stage.Get(), sharedTex[slot].Get());
 
         // Release back to producer ASAP
-        mutex->ReleaseSync(0);
+        mutexes[slot]->ReleaseSync(0);
 
         D3D11_MAPPED_SUBRESOURCE m{};
         hr = ctx->Map(stage.Get(), 0, D3D11_MAP_READ, 0, &m);
@@ -335,10 +407,11 @@ int main(int argc, char** argv)
 
         UINT64 dCnt = cnt - lastCounter;
         lastCounter = cnt;
-        printf("[frame %3d] dumped=%s path=%s frameCounter=%llu (+%llu)\n",
+        printf("[frame %3d] dumped=%s path=%s frameCounter=%llu (+%llu) slot=%u\n",
                captured, dumped ? "OK" : "FAIL", path,
                static_cast<unsigned long long>(cnt),
-               static_cast<unsigned long long>(dCnt));
+               static_cast<unsigned long long>(dCnt),
+               slot);
 
         ++captured;
     }


### PR DESCRIPTION
﻿## 做了什么

这是 Sunshine borrowed texture direct capture 的 VDD producer 侧配套实现：VDD 不再只发布单张 shared texture，而是发布一个 3 槽 mailbox/ring，让 consumer 可以借用最新 slot，同时 producer 仍然保持 latest-frame-wins，不因为 consumer 持有一帧就阻塞 IddCx present loop。

```mermaid
flowchart TD
  A[IddCx acquired frame] --> B[SharedFrameExporter::PushFrame]
  B --> C{Find empty slot key 0}
  C -->|found| D[CopyResource into selected shared slot]
  C -->|none| E{Can reclaim unread slot key 1?}
  E -->|yes| F[Replace unread frame]
  E -->|no| G[Record dropped/held stats and skip publish]
  D --> H[Update metadata: slot, frame counter, dirty/drop stats, LUID]
  F --> H
  H --> I[Release keyed mutex as key 1]
  I --> J[Signal frame-ready event]
  J --> K[Sunshine opens Global\\ZakoVDD_Frame_* slot]
```

- `SharedFrameExporter` 改为 3 槽 shared texture ring，每个 slot 都有独立 named shared handle 和 keyed mutex。
- Metadata 增加 `MetadataSize`、`SlotCount`、`SlotIndex`、adapter LUID、producer QPC frequency、dirty rect count、drop/replaced counters。
- Producer 发布时优先找 key 0 空槽；找不到时尝试回收 key 1 unread slot，实现 latest-frame-wins mailbox。
- 如果 consumer 仍持有所有 slot，会记录 `DroppedConsumerHeldFrames` / `DroppedAcquireFailures`，避免阻塞驱动 render path。
- `vdd_capture_test` 更新为读取 slot metadata、打开所有 shared slots，并按 latest `SlotIndex` acquire/copy/release。

## 目标与价值

- 给 Sunshine 的 VDD borrowed texture path 提供 producer 侧多槽缓冲，减少单槽 keyed mutex 对 4K120 流的卡顿风险。
- 让 consumer 可以直接识别最新 slot，而不是猜测单一 texture 状态。
- 保留可观测性：replaced、dropped、dirty rect、adapter LUID、QPC 信息都暴露给 consumer 和测试工具。
- 在 consumer 慢或异常时保持驱动侧非阻塞，坏状态不要把 IddCx loop 拖进泥潭。

## 验证

- `git diff --check -- ZakoVDD/Rendering/SharedFrameExporter.cpp ZakoVDD/Rendering/SharedFrameExporter.h tools/vdd_capture_test/vdd_capture_test.cpp`
- `MSBuild.exe ZakoVDD.sln /p:Configuration=Release /p:Platform=x64 /m /v:minimal`
  - 输出生成并签名 `x64\Release\ZakoVDD.dll`
  - Signability/Catalog generation reported `Errors: None`
  - Windows Kit logged an `InfVerif.dll` load exception, but MSBuild completed with exit code 0 and produced/signed artifacts
- `cl /nologo /std:c++17 /EHsc ... tools\vdd_capture_test\vdd_capture_test.cpp /link d3d11.lib dxgi.lib`
