### PR TITLE
fix(vdd): skip startup GPU usability probe

### DIFF
--- a/ZakoVDD/Device/IndirectDeviceContext.cpp
+++ b/ZakoVDD/Device/IndirectDeviceContext.cpp
@@ -84,21 +84,21 @@ IndirectDeviceContext::~IndirectDeviceContext()
 void IndirectDeviceContext::InitAdapter()
 {
 	loadSettings();
-	wstring requestedGpuName;
 	if (gpuname.empty() || SameGpuName(gpuname, L"default"))
 	{
 		const wstring adaptername = confpath + L"\\adapter.txt";
-		requestedGpuName = ReadAdapterPreferenceFile(adaptername);
 		Options.Adapter.load(adaptername.c_str());
 		VDD_LOG_INFO("Attempting to Load GPU from adapter.txt");
 	}
 	else
 	{
-		requestedGpuName = gpuname;
 		Options.Adapter.xmlprovide(gpuname);
 		VDD_LOG_INFO("Loading GPU from vdd_settings.xml");
 	}
-	EnsureUsableRenderAdapter(Options.Adapter, requestedGpuName);
+	// Avoid probing D3D11 render-adapter usability during UMDF D0 startup.
+	// Some Intel display stacks can hang WUDFHost while the virtual display
+	// adapter is still initializing. Sunshine should validate explicit GPU
+	// selections before writing them to the driver configuration instead.
 	GetGpuInfo();
 
 	int edidResult = LoadKnownMonitorEdid();


### PR DESCRIPTION
## 改了啥

- 在 VDD `InitAdapter()` 启动路径里不再调用 `EnsureUsableRenderAdapter()`。
- 保留原来的 `adapter.txt` / `vdd_settings.xml` GPU 选择和 `GetGpuInfo()` 日志。
- 留下注释说明：显式 GPU 选择应由 Sunshine 用户态提前校验，不要在 UMDF D0 启动阶段探测 D3D11 可用性。

## 为啥要改

Intel B390 / Honor / 26H1 用户反馈新版 VDD 会让系统卡顿、重启黑屏，并出现 DriverFrameworks-UserMode `10120 + 10111`。ETW/WER 指向 `WUDFHostProblem2 / HostTimeout`，且卡在 adapter init 启动阶段，不是串流帧导出路径。

定位包结果很明确，杂鱼问题被抓到了：

- `00-v0157-0611-official-zakovdd.zip` 正常
- `01-v0161-extra-logs-control.zip` 复现卡顿和 `10120 / 10111`
- `02-v0161-no-ensure-render-adapter.zip` 安装后正常

所以启动期 `D3D11CreateDevice()` GPU 可用性探测在部分 Intel 显示栈上风险太高。这个 PR 先回到更保守的启动路径，避免 VDD 把系统显示栈拖进 WUDFHost timeout。

## 验证

- 本地构建：`MSBuild.exe ZakoVDD.sln /p:Configuration=Release /p:Platform=x64 /t:Build /m`
- 生成 `ZakoVDD.dll` / `ZakoVDD.inf` / `zakovdd.cat`
- `Inf2Cat` signability: `Errors: None`, `Warnings: None`
- `zakovdd.cat` Authenticode signature: `Valid`

备注：本机 WDK 的 MSBuild `InfVerif` target 会打印 `无法加载 DLL“x86\InfVerif.dll”`，但 MSBuild 退出码为 0，后续 `Inf2Cat` 和签名均成功。