### PR TITLE
feat(vulkan): add verified HDR compatibility bridge

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -105,6 +105,16 @@ jobs:
         run: |
           msbuild "ZakoVDD.sln" /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
 
+      - name: Build Vulkan HDR diagnostics
+        shell: cmd
+        run: |
+          call tools\vulkan_hdr_policy_test\build_consumer.bat
+          call tools\vulkan_hdr_probe\build_consumer.bat
+          call tools\vulkan_hdr_bridge\build_consumer.bat
+          call tools\vdd_command\build_consumer.bat
+          call tools\desktop_hdr_capture\build_consumer.bat
+          call tools\vdd_capture_test\build_consumer.bat
+
       - name: Stamp driver version
         shell: pwsh
         run: |
@@ -239,6 +249,9 @@ jobs:
             ${{ matrix.platform }}\${{ matrix.configuration }}\ZakoVDD\zakovdd.cat
             ${{ matrix.platform }}\${{ matrix.configuration }}\ZakoVDD\vdd_settings.xml
             ${{ matrix.platform }}\${{ matrix.configuration }}\ZakoVDD.cer
+            tools\vulkan_hdr_bridge\build\zako_vulkan_hdr_bridge.dll
+            tools\vulkan_hdr_bridge\build\VkLayer_zako_virtual_hdr.json
+            tools\vulkan_hdr_probe\build\vulkan_hdr_probe.exe
 
   release:
     name: Create Release
@@ -262,10 +275,14 @@ jobs:
             ZakoVDD/ZakoVDD.inf \
             ZakoVDD/zakovdd.cat \
             ZakoVDD/vdd_settings.xml \
-            ZakoVDD.cer
+            ZakoVDD.cer \
+            tools/vulkan_hdr_bridge/build/zako_vulkan_hdr_bridge.dll \
+            tools/vulkan_hdr_bridge/build/VkLayer_zako_virtual_hdr.json \
+            tools/vulkan_hdr_probe/build/vulkan_hdr_probe.exe
           cd ..
           unzip -l zakovdd.zip
-          for required in ZakoVDD.dll ZakoVDD.inf zakovdd.cat vdd_settings.xml ZakoVDD.cer; do
+          for required in ZakoVDD.dll ZakoVDD.inf zakovdd.cat vdd_settings.xml ZakoVDD.cer \
+                          zako_vulkan_hdr_bridge.dll VkLayer_zako_virtual_hdr.json vulkan_hdr_probe.exe; do
             unzip -l zakovdd.zip "$required" >/dev/null
           done
           ls -la zakovdd.zip

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -108,12 +108,12 @@ jobs:
       - name: Build Vulkan HDR diagnostics
         shell: cmd
         run: |
-          call tools\vulkan_hdr_policy_test\build_consumer.bat
-          call tools\vulkan_hdr_probe\build_consumer.bat
-          call tools\vulkan_hdr_bridge\build_consumer.bat
-          call tools\vdd_command\build_consumer.bat
-          call tools\desktop_hdr_capture\build_consumer.bat
-          call tools\vdd_capture_test\build_consumer.bat
+          call tools\vulkan_hdr_policy_test\build_consumer.bat || exit /b 1
+          call tools\vulkan_hdr_probe\build_consumer.bat || exit /b 1
+          call tools\vulkan_hdr_bridge\build_consumer.bat || exit /b 1
+          call tools\vdd_command\build_consumer.bat || exit /b 1
+          call tools\desktop_hdr_capture\build_consumer.bat || exit /b 1
+          call tools\vdd_capture_test\build_consumer.bat || exit /b 1
 
       - name: Stamp driver version
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,7 @@ ModelManifest.xml
 nul
 tools/nul
 tools/dist/
+tools/**/build/
 tools/VkLayer_hdr_inject/full_debug.txt
 tools/VkLayer_hdr_inject/hdr_inject_log.txt
 tools/VkLayer_hdr_inject/external/

--- a/Common/Include/README.md
+++ b/Common/Include/README.md
@@ -1,6 +1,12 @@
-驱动和配套工具共享的头文件。
+# Shared headers
 
-- `vdd_control_ioctl.h` 定义控制通道的 IOCTL 协议。
-- `AdapterOption.h` 定义驱动模块之间共享的适配器选择状态。
+This directory contains contracts shared across the driver and companion
+tools:
 
-这个目录只放确实需要跨驱动子系统或被外部工具复用的头文件。
+- `vdd_control_ioctl.h`: ZakoVDD control and sealed frame-channel IOCTL ABI.
+- `AdapterOption.h`: adapter-selection state shared by driver modules.
+- `vulkan_hdr_policy.h`: strict HDR surface-format injection policy.
+- `vulkan_hdr_capability_cache.h`: versioned GPU/driver/OS validation cache.
+
+Keep only cross-component contracts here. Driver-internal implementation
+details belong under `ZakoVDD`.

--- a/Common/Include/vulkan_hdr_capability_cache.h
+++ b/Common/Include/vulkan_hdr_capability_cache.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace zako::vulkan_hdr {
+
+inline constexpr std::uint32_t kCapabilityCacheMagic = 0x5A564843;  // 'ZVHC'
+inline constexpr std::uint16_t kCapabilityCacheVersion = 1;
+inline constexpr std::uint32_t kCapabilityHdr10Swapchain = 0x00000001u;
+inline constexpr std::uint32_t kCapabilityScRgbSwapchain = 0x00000002u;
+inline constexpr std::uint32_t kCapabilityValidatedWhileHdrActive = 0x00000004u;
+inline constexpr std::uint32_t kCapabilityPresented = 0x00000008u;
+inline constexpr std::uint32_t kCapabilityPixelsVerified = 0x00000010u;
+
+struct CapabilityCacheHeader {
+  std::uint32_t magic {kCapabilityCacheMagic};
+  std::uint16_t version {kCapabilityCacheVersion};
+  std::uint16_t header_size {sizeof(CapabilityCacheHeader)};
+  std::uint32_t entry_size {};
+  std::uint32_t entry_count {};
+};
+
+struct CapabilityCacheEntry {
+  std::uint32_t vendor_id {};
+  std::uint32_t device_id {};
+  std::uint32_t driver_version {};
+  std::uint32_t api_version {};
+  std::uint32_t adapter_luid_low {};
+  std::int32_t adapter_luid_high {};
+  std::uint32_t windows_build {};
+  std::uint32_t flags {};
+  char device_name[128] {};
+  std::uint32_t reserved[8] {};
+};
+
+static_assert(sizeof(CapabilityCacheHeader) == 16);
+static_assert(sizeof(CapabilityCacheEntry) == 192);
+
+inline bool same_capability_key(const CapabilityCacheEntry& left, const CapabilityCacheEntry& right) {
+  return left.vendor_id == right.vendor_id && left.device_id == right.device_id &&
+         left.driver_version == right.driver_version && left.api_version == right.api_version &&
+         left.adapter_luid_low == right.adapter_luid_low && left.adapter_luid_high == right.adapter_luid_high &&
+         left.windows_build == right.windows_build;
+}
+
+inline std::vector<CapabilityCacheEntry> read_capability_cache(const std::wstring& path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input) return {};
+  CapabilityCacheHeader header {};
+  input.read(reinterpret_cast<char*>(&header), sizeof(header));
+  if (!input || header.magic != kCapabilityCacheMagic || header.version != kCapabilityCacheVersion ||
+      header.header_size != sizeof(header) || header.entry_size != sizeof(CapabilityCacheEntry) ||
+      header.entry_count > 64) return {};
+  std::vector<CapabilityCacheEntry> entries(header.entry_count);
+  input.read(reinterpret_cast<char*>(entries.data()), static_cast<std::streamsize>(entries.size() * sizeof(CapabilityCacheEntry)));
+  if (!input) return {};
+  return entries;
+}
+
+inline bool write_capability_cache(const std::wstring& path, const std::vector<CapabilityCacheEntry>& entries) {
+  CapabilityCacheHeader header {};
+  header.entry_size = sizeof(CapabilityCacheEntry);
+  header.entry_count = static_cast<std::uint32_t>(entries.size());
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output) return false;
+  output.write(reinterpret_cast<const char*>(&header), sizeof(header));
+  output.write(reinterpret_cast<const char*>(entries.data()), static_cast<std::streamsize>(entries.size() * sizeof(CapabilityCacheEntry)));
+  return output.good();
+}
+
+inline void upsert_capability(std::vector<CapabilityCacheEntry>& entries, const CapabilityCacheEntry& value) {
+  const auto found = std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
+    return same_capability_key(entry, value);
+  });
+  if (found == entries.end()) entries.push_back(value);
+  else *found = value;
+}
+
+}  // namespace zako::vulkan_hdr

--- a/Common/Include/vulkan_hdr_policy.h
+++ b/Common/Include/vulkan_hdr_policy.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace zako::vulkan_hdr {
+
+struct FormatPair {
+  std::int32_t format {};
+  std::int32_t color_space {};
+
+  friend constexpr bool operator==(const FormatPair& left, const FormatPair& right) {
+    return left.format == right.format && left.color_space == right.color_space;
+  }
+};
+
+inline constexpr FormatPair kHdr10Pair {64, 1000104008};
+inline constexpr FormatPair kScRgbPair {97, 1000104002};
+
+inline bool contains_pair(const std::vector<FormatPair>& formats, FormatPair pair) {
+  return std::find(formats.begin(), formats.end(), pair) != formats.end();
+}
+
+inline void append_missing_verified_pairs(std::vector<FormatPair>& formats, bool allow_hdr10, bool allow_scrgb) {
+  if (allow_scrgb && !contains_pair(formats, kScRgbPair)) formats.push_back(kScRgbPair);
+  if (allow_hdr10 && !contains_pair(formats, kHdr10Pair)) formats.push_back(kHdr10Pair);
+}
+
+}  // namespace zako::vulkan_hdr

--- a/ZakoVDD/ZakoVDD.vcxproj
+++ b/ZakoVDD/ZakoVDD.vcxproj
@@ -63,7 +63,10 @@
     <ClInclude Include="Util\StringConversion.h" />
   </ItemGroup>
   <ItemGroup>
-    <Inf Include="ZakoVDD.inf" />
+    <Inf Include="ZakoVDD.inf">
+      <SpecifyDriverVerDirectiveVersion>true</SpecifyDriverVerDirectiveVersion>
+      <TimeStamp>$(DriverPackageVersion)</TimeStamp>
+    </Inf>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2D54CB75-8B17-4F11-97DC-847B0244CD46}</ProjectGuid>
@@ -73,6 +76,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>ZakoVDD</RootNamespace>
+    <DriverPackageVersion Condition="'$(DriverPackageVersion)' == ''">*</DriverPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>

--- a/tools/desktop_hdr_capture/README.md
+++ b/tools/desktop_hdr_capture/README.md
@@ -1,0 +1,13 @@
+# Desktop HDR capture diagnostic
+
+`desktop_hdr_capture` tests whether DXGI Desktop Duplication can acquire an
+FP16 desktop image from an active HDR display. It is a diagnostic fallback,
+not the VDD production capture path.
+
+```cmd
+build\desktop_hdr_capture.exe \\.\DISPLAY7 100 100 5000
+```
+
+IddCx outputs commonly return `DXGI_ERROR_UNSUPPORTED` from
+`DuplicateOutput1`. Use `vdd_capture_test` and the driver's shared-frame
+channel for the authoritative VDD pixel check.

--- a/tools/desktop_hdr_capture/build.bat
+++ b/tools/desktop_hdr_capture/build.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+if not exist build mkdir build
+cl /nologo /std:c++17 /EHsc /W4 /O2 /DUNICODE /D_UNICODE /Fo:build\ /Fe:build\desktop_hdr_capture.exe ^
+   desktop_hdr_capture.cpp d3d11.lib dxgi.lib
+exit /b %ERRORLEVEL%

--- a/tools/desktop_hdr_capture/build_consumer.bat
+++ b/tools/desktop_hdr_capture/build_consumer.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 exit /b 1
+call "%~dp0build.bat"
+exit /b %ERRORLEVEL%

--- a/tools/desktop_hdr_capture/desktop_hdr_capture.cpp
+++ b/tools/desktop_hdr_capture/desktop_hdr_capture.cpp
@@ -1,0 +1,175 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <d3d11.h>
+#include <dxgi1_5.h>
+#include <wrl/client.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+float half_to_float(std::uint16_t value) {
+  const std::uint32_t sign = static_cast<std::uint32_t>(value & 0x8000u) << 16;
+  std::uint32_t exponent = (value >> 10) & 0x1fu;
+  std::uint32_t mantissa = value & 0x3ffu;
+  std::uint32_t bits = 0;
+  if (exponent == 0) {
+    if (mantissa == 0) bits = sign;
+    else {
+      exponent = 127 - 15 + 1;
+      while ((mantissa & 0x400u) == 0) { mantissa <<= 1; --exponent; }
+      bits = sign | (exponent << 23) | ((mantissa & 0x3ffu) << 13);
+    }
+  } else if (exponent == 31) bits = sign | 0x7f800000u | (mantissa << 13);
+  else bits = sign | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+  float result = 0;
+  std::memcpy(&result, &bits, sizeof(result));
+  return result;
+}
+
+const char* format_name(DXGI_FORMAT format) {
+  switch (format) {
+    case DXGI_FORMAT_R16G16B16A16_FLOAT: return "RGBA16F";
+    case DXGI_FORMAT_R10G10B10A2_UNORM: return "RGB10A2";
+    case DXGI_FORMAT_B8G8R8A8_UNORM: return "BGRA8";
+    default: return "OTHER";
+  }
+}
+
+}  // namespace
+
+int wmain(int argc, wchar_t** argv) {
+  if (argc < 2) {
+    std::cout << "Usage: desktop_hdr_capture.exe \\\\.\\DISPLAYn [x y] [timeout_ms]\n";
+    return 2;
+  }
+  const std::wstring display = argv[1];
+  const UINT sample_x = argc > 2 ? static_cast<UINT>(std::wcstoul(argv[2], nullptr, 10)) : 100;
+  const UINT sample_y = argc > 3 ? static_cast<UINT>(std::wcstoul(argv[3], nullptr, 10)) : 100;
+  const UINT timeout = argc > 4 ? static_cast<UINT>(std::wcstoul(argv[4], nullptr, 10)) : 5000;
+
+  ComPtr<IDXGIFactory1> factory;
+  HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory));
+  if (FAILED(hr)) return 3;
+
+  ComPtr<IDXGIAdapter1> selected_adapter;
+  ComPtr<IDXGIOutput> selected_output;
+  DXGI_OUTPUT_DESC output_desc {};
+  for (UINT adapter_index = 0; !selected_output; ++adapter_index) {
+    ComPtr<IDXGIAdapter1> adapter;
+    if (factory->EnumAdapters1(adapter_index, &adapter) == DXGI_ERROR_NOT_FOUND) break;
+    for (UINT output_index = 0;; ++output_index) {
+      ComPtr<IDXGIOutput> output;
+      if (adapter->EnumOutputs(output_index, &output) == DXGI_ERROR_NOT_FOUND) break;
+      DXGI_OUTPUT_DESC desc {};
+      if (SUCCEEDED(output->GetDesc(&desc)) && _wcsicmp(desc.DeviceName, display.c_str()) == 0) {
+        selected_adapter = adapter;
+        selected_output = output;
+        output_desc = desc;
+        break;
+      }
+    }
+  }
+  if (!selected_output) {
+    std::wcerr << L"error=output_not_found display=" << display << L'\n';
+    return 4;
+  }
+
+  ComPtr<ID3D11Device> device;
+  ComPtr<ID3D11DeviceContext> context;
+  D3D_FEATURE_LEVEL level {};
+  hr = D3D11CreateDevice(selected_adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr,
+                         D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0, D3D11_SDK_VERSION,
+                         &device, &level, &context);
+  if (FAILED(hr)) {
+    std::cerr << "error=D3D11CreateDevice hr=" << std::hex << hr << '\n';
+    return 5;
+  }
+
+  ComPtr<IDXGIOutput5> output5;
+  if (FAILED(selected_output.As(&output5))) {
+    std::cerr << "error=IDXGIOutput5_unavailable\n";
+    return 6;
+  }
+  const DXGI_FORMAT requested[] = {
+    DXGI_FORMAT_R16G16B16A16_FLOAT,
+    DXGI_FORMAT_R10G10B10A2_UNORM,
+    DXGI_FORMAT_B8G8R8A8_UNORM,
+  };
+  ComPtr<IDXGIOutputDuplication> duplication;
+  hr = output5->DuplicateOutput1(device.Get(), 0, static_cast<UINT>(std::size(requested)), requested, &duplication);
+  if (FAILED(hr)) {
+    std::cerr << "error=DuplicateOutput1 hr=0x" << std::hex << hr << '\n';
+    return 7;
+  }
+
+  DXGI_OUTDUPL_FRAME_INFO frame_info {};
+  ComPtr<IDXGIResource> resource;
+  hr = duplication->AcquireNextFrame(timeout, &frame_info, &resource);
+  if (FAILED(hr)) {
+    std::cerr << "error=AcquireNextFrame hr=0x" << std::hex << hr << '\n';
+    return 8;
+  }
+  ComPtr<ID3D11Texture2D> texture;
+  resource.As(&texture);
+  D3D11_TEXTURE2D_DESC desc {};
+  texture->GetDesc(&desc);
+  D3D11_TEXTURE2D_DESC staging_desc = desc;
+  staging_desc.Usage = D3D11_USAGE_STAGING;
+  staging_desc.BindFlags = 0;
+  staging_desc.MiscFlags = 0;
+  staging_desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+  ComPtr<ID3D11Texture2D> staging;
+  hr = device->CreateTexture2D(&staging_desc, nullptr, &staging);
+  if (FAILED(hr)) {
+    duplication->ReleaseFrame();
+    return 9;
+  }
+  context->CopyResource(staging.Get(), texture.Get());
+  D3D11_MAPPED_SUBRESOURCE mapped {};
+  hr = context->Map(staging.Get(), 0, D3D11_MAP_READ, 0, &mapped);
+  if (FAILED(hr)) {
+    duplication->ReleaseFrame();
+    return 10;
+  }
+
+  const UINT x = std::min(sample_x, desc.Width - 1);
+  const UINT y = std::min(sample_y, desc.Height - 1);
+  const auto* row = static_cast<const std::uint8_t*>(mapped.pData) + y * mapped.RowPitch;
+  float r = 0, g = 0, b = 0, a = 0;
+  if (desc.Format == DXGI_FORMAT_R16G16B16A16_FLOAT) {
+    const auto* pixel = reinterpret_cast<const std::uint16_t*>(row + x * 8);
+    r = half_to_float(pixel[0]); g = half_to_float(pixel[1]); b = half_to_float(pixel[2]); a = half_to_float(pixel[3]);
+  } else if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) {
+    const auto pixel = *reinterpret_cast<const std::uint32_t*>(row + x * 4);
+    r = static_cast<float>(pixel & 0x3ffu) / 1023.0f;
+    g = static_cast<float>((pixel >> 10) & 0x3ffu) / 1023.0f;
+    b = static_cast<float>((pixel >> 20) & 0x3ffu) / 1023.0f;
+    a = static_cast<float>((pixel >> 30) & 0x3u) / 3.0f;
+  } else if (desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM) {
+    const auto* pixel = row + x * 4;
+    b = pixel[0] / 255.0f; g = pixel[1] / 255.0f; r = pixel[2] / 255.0f; a = pixel[3] / 255.0f;
+  }
+  context->Unmap(staging.Get(), 0);
+  duplication->ReleaseFrame();
+
+  std::cout << "display=";
+  std::wcout << display;
+  std::cout << " desktop_bounds=" << output_desc.DesktopCoordinates.left << ',' << output_desc.DesktopCoordinates.top
+            << ',' << output_desc.DesktopCoordinates.right << ',' << output_desc.DesktopCoordinates.bottom
+            << " texture=" << desc.Width << 'x' << desc.Height << " format=" << format_name(desc.Format)
+            << '(' << desc.Format << ") sample=" << x << ',' << y
+            << " rgba=" << r << ',' << g << ',' << b << ',' << a << '\n';
+  if (desc.Format == DXGI_FORMAT_R16G16B16A16_FLOAT) {
+    std::cout << "scrgb_1000nit_patch_match=" << (r > 10.0f && g > 10.0f && b > 10.0f) << '\n';
+  }
+  return 0;
+}

--- a/tools/vdd_capture_test/README.md
+++ b/tools/vdd_capture_test/README.md
@@ -1,69 +1,43 @@
-# vdd_capture_test
+# VDD shared-frame capture test
 
-`vdd_capture_test` 是独立 consumer，用于验证 ZakoVDD 的
-`SharedFrameExporter` 可以把 IddCx 帧导出给外部进程，不经过 DXGI Desktop
-Duplication 或 Windows Graphics Capture。
+`vdd_capture_test` consumes the frame ring exported by ZakoVDD without DXGI
+Desktop Duplication or Windows Graphics Capture. It opens the metadata mapping,
+frame-ready event, and keyed-mutex D3D11 textures for one VDD monitor.
 
-## 工作原理
-
-驱动会为每个虚拟显示器发布以下共享对象：
-
-| 资源 | 命名 |
-| --- | --- |
-| 带 keyed mutex 的 D3D11 共享纹理 | `Global\ZakoVDD_Frame_<idx>` |
-| 帧就绪事件 | `Global\ZakoVDD_FrameReady_<idx>` |
-| 元数据 file mapping | `Global\ZakoVDD_Meta_<idx>` |
-
-每帧从 IddCx 收到的 surface 会被复制到共享纹理。本工具打开这些共享对象，
-通过 keyed mutex 同步，然后把帧 dump 成 PPM 文件做视觉验证。
-
-## 编译
-
-打开 **x64 Native Tools Command Prompt for VS 2022**，然后运行：
+Build from an x64 Visual Studio 2022 developer prompt:
 
 ```cmd
 build.bat
 ```
 
-输出文件为 `build\vdd_capture_test.exe`。
-
-## 使用
-
-运行前需要满足：
-
-1. 已安装包含 `SharedFrameExporter` 的 ZakoVDD 构建。
-2. 至少创建了一个虚拟显示器。
-3. 虚拟显示器处于活动状态，确保 DWM 会持续推帧。
+Capture five frames:
 
 ```cmd
-build\vdd_capture_test.exe --monitor 0 --frames 5 --out .
+build\vdd_capture_test.exe --monitor 0 --frames 5 --out build\capture
 ```
 
-| 参数 | 默认 | 说明 |
-| --- | --- | --- |
-| `--monitor N` | `0` | ZakoVDD 内部 monitor index。 |
-| `--frames N` | `5` | 要捕获的帧数。 |
-| `--out DIR` | `.` | PPM 帧文件输出目录。 |
-| `--timeout MS` | `2000` | 每帧等待超时。 |
+Verify a known scRGB pixel without writing large raw frame files:
 
-## 期望输出
-
-```text
-[vdd_capture_test] monitor=0 frames=5 out=. timeout=2000ms
-[meta] 1920x1080 fmt=BGRA8(87) hdr=0 maxNits=0.0 frameCounter=42
-[shared] tex 1920x1080 fmt=BGRA8(87) bind=0x28 misc=0x802
-[frame   0] dumped=OK path=./vdd_frame_000.ppm frameCounter=43 (+1)
-[frame   1] dumped=OK path=./vdd_frame_001.ppm frameCounter=44 (+1)
-[done] captured=5 in 0.083s (60.0 fps)
+```cmd
+build\vdd_capture_test.exe --monitor 0 --frames 3 --sample 100 100 ^
+  --expect-rgb 0 12.5 0 --tolerance 0.5 --no-dump
 ```
 
-## 故障排查
+Important options:
 
-- `OpenFileMappingW failed: 2`：驱动未运行、未安装 exporter 构建，或选中的
-  monitor 未处于活动状态。
-- `OpenFileMappingW failed: 5`：当前进程没有访问权限。检查共享对象 SDDL；
-  默认授权 system、administrators 和 interactive users。
-- `OpenSharedResourceByName failed: 0x80070057`：工具使用的 D3D11 设备 LUID
-  和驱动 render adapter LUID 不一致。
-- 持续 timeout 通常表示虚拟显示器没有收到帧。把可见窗口移动到该显示器上，
-  或把它设为扩展桌面。
+- `--monitor N`: internal ZakoVDD monitor index, default `0`.
+- `--frames N`: number of frames, default `5`.
+- `--timeout MS`: per-frame timeout, default `2000`.
+- `--sample X Y`: decode and print one pixel from an RGBA16F frame.
+- `--expect-scrgb V`: expect the same scRGB value in R, G, and B.
+- `--expect-rgb R G B`: expect independent scRGB channel values.
+- `--tolerance V`: absolute per-channel tolerance, default `0.25`.
+- `--no-dump`: validate metadata/pixels without writing PPM/raw frames.
+
+The tool exits nonzero if no frame is captured or no sampled frame matches the
+requested value. Pixel verification is intended to run while
+`vulkan_hdr_probe --present scrgb --clear ...` holds a visible patch on the
+active HDR VDD.
+
+The compatibility named-object channel may require an elevated consumer. The
+production Sunshine path should use the sealed IOCTL frame channel instead.

--- a/tools/vdd_capture_test/build_consumer.bat
+++ b/tools/vdd_capture_test/build_consumer.bat
@@ -1,6 +1,9 @@
 @echo off
 setlocal
-call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
 if errorlevel 1 (echo vcvars64 failed & exit /b 1)
 call "%~dp0build.bat"
 exit /b %ERRORLEVEL%

--- a/tools/vdd_capture_test/build_vdd.bat
+++ b/tools/vdd_capture_test/build_vdd.bat
@@ -3,7 +3,9 @@ setlocal
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" >nul
 if errorlevel 1 (echo vcvars64 failed & exit /b 1)
 pushd "%~dp0..\.."
-msbuild ZakoVDD.sln /p:Configuration=Release /p:Platform=x64 /m /v:minimal /nologo
+set "VERSION_ARG="
+if defined DRIVER_PACKAGE_VERSION set "VERSION_ARG=/p:DriverPackageVersion=%DRIVER_PACKAGE_VERSION%"
+msbuild ZakoVDD.sln /p:Configuration=Release /p:Platform=x64 %VERSION_ARG% /m /v:minimal /nologo
 set "BUILD_EXIT=%ERRORLEVEL%"
 popd
 exit /b %BUILD_EXIT%

--- a/tools/vdd_capture_test/vdd_capture_test.cpp
+++ b/tools/vdd_capture_test/vdd_capture_test.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 #include <chrono>
 #include <fstream>
+#include <cmath>
 
 #pragma comment(lib, "d3d11.lib")
 #pragma comment(lib, "dxgi.lib")
@@ -70,6 +71,12 @@ struct Args
     int frames = 5;
     std::string out = ".";
     DWORD timeoutMs = 2000;
+    int sampleX = -1;
+    int sampleY = -1;
+    float expectedRgb[3] {};
+    bool hasExpectedRgb = false;
+    float tolerance = 0.25f;
+    bool dumpFrames = true;
 };
 
 static Args ParseArgs(int argc, char** argv)
@@ -86,14 +93,66 @@ static Args ParseArgs(int argc, char** argv)
         else if (s == "--frames") a.frames = std::stoi(next("--frames"));
         else if (s == "--out") a.out = next("--out");
         else if (s == "--timeout") a.timeoutMs = static_cast<DWORD>(std::stoul(next("--timeout")));
+        else if (s == "--sample")
+        {
+            a.sampleX = std::stoi(next("--sample"));
+            a.sampleY = std::stoi(next("--sample"));
+        }
+        else if (s == "--expect-scrgb")
+        {
+            const float expected = std::stof(next("--expect-scrgb"));
+            a.expectedRgb[0] = a.expectedRgb[1] = a.expectedRgb[2] = expected;
+            a.hasExpectedRgb = true;
+        }
+        else if (s == "--expect-rgb")
+        {
+            a.expectedRgb[0] = std::stof(next("--expect-rgb"));
+            a.expectedRgb[1] = std::stof(next("--expect-rgb"));
+            a.expectedRgb[2] = std::stof(next("--expect-rgb"));
+            a.hasExpectedRgb = true;
+        }
+        else if (s == "--tolerance") a.tolerance = std::stof(next("--tolerance"));
+        else if (s == "--no-dump") a.dumpFrames = false;
         else if (s == "-h" || s == "--help")
         {
-            printf("vdd_capture_test [--monitor N] [--frames N] [--out DIR] [--timeout MS]\n");
+            printf("vdd_capture_test [--monitor N] [--frames N] [--out DIR] [--timeout MS] "
+                   "[--sample X Y] [--expect-scrgb V | --expect-rgb R G B] "
+                   "[--tolerance V] [--no-dump]\n");
             exit(0);
         }
         else { fprintf(stderr, "Unknown arg: %s\n", s.c_str()); exit(2); }
     }
     return a;
+}
+
+static float HalfToFloat(uint16_t half)
+{
+    const uint32_t sign = static_cast<uint32_t>(half & 0x8000u) << 16;
+    uint32_t exponent = (half >> 10) & 0x1fu;
+    uint32_t mantissa = half & 0x03ffu;
+    uint32_t bits = 0;
+    if (exponent == 0)
+    {
+        if (mantissa == 0) bits = sign;
+        else
+        {
+            int shift = 0;
+            while ((mantissa & 0x0400u) == 0) { mantissa <<= 1; ++shift; }
+            mantissa &= 0x03ffu;
+            bits = sign | (static_cast<uint32_t>(127 - 15 - shift) << 23) | (mantissa << 13);
+        }
+    }
+    else if (exponent == 31)
+    {
+        bits = sign | 0x7f800000u | (mantissa << 13);
+    }
+    else
+    {
+        bits = sign | ((exponent + (127 - 15)) << 23) | (mantissa << 13);
+    }
+    float value = 0.0f;
+    std::memcpy(&value, &bits, sizeof(value));
+    return value;
 }
 
 static const char* DxgiFormatName(DXGI_FORMAT f)
@@ -331,6 +390,7 @@ int main(int argc, char** argv)
     }
 
     int captured = 0;
+    int matchingSamples = 0;
     auto t0 = std::chrono::steady_clock::now();
     UINT64 lastCounter = meta->FrameCounter;
 
@@ -383,8 +443,31 @@ int main(int argc, char** argv)
         snprintf(path, sizeof(path), "%s/vdd_frame_%03d.ppm", args.out.c_str(), captured);
 
         bool isBgr = (desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM);
-        bool dumped = false;
-        if (desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM ||
+        bool dumped = !args.dumpFrames;
+        if (args.sampleX >= 0 && args.sampleY >= 0 &&
+            desc.Format == DXGI_FORMAT_R16G16B16A16_FLOAT &&
+            static_cast<UINT>(args.sampleX) < desc.Width &&
+            static_cast<UINT>(args.sampleY) < desc.Height)
+        {
+            const auto* pixel = reinterpret_cast<const uint16_t*>(
+                static_cast<const uint8_t*>(m.pData) + args.sampleY * m.RowPitch) + args.sampleX * 4;
+            const float r = HalfToFloat(pixel[0]);
+            const float g = HalfToFloat(pixel[1]);
+            const float b = HalfToFloat(pixel[2]);
+            const float a = HalfToFloat(pixel[3]);
+            const bool match = !args.hasExpectedRgb ||
+                (std::fabs(r - args.expectedRgb[0]) <= args.tolerance &&
+                 std::fabs(g - args.expectedRgb[1]) <= args.tolerance &&
+                 std::fabs(b - args.expectedRgb[2]) <= args.tolerance);
+            if (match) ++matchingSamples;
+            printf("[sample %3d] xy=%d,%d rgba=%.4f,%.4f,%.4f,%.4f match=%u\n",
+                   captured, args.sampleX, args.sampleY, r, g, b, a, match ? 1u : 0u);
+        }
+        if (!args.dumpFrames)
+        {
+            snprintf(path, sizeof(path), "<not-dumped>");
+        }
+        else if (desc.Format == DXGI_FORMAT_B8G8R8A8_UNORM ||
             desc.Format == DXGI_FORMAT_R8G8B8A8_UNORM)
         {
             dumped = DumpPpm(path, static_cast<const uint8_t*>(m.pData),
@@ -419,9 +502,16 @@ int main(int argc, char** argv)
     auto t1 = std::chrono::steady_clock::now();
     double sec = std::chrono::duration<double>(t1 - t0).count();
     printf("[done] captured=%d in %.3fs (%.1f fps)\n", captured, sec, captured / (sec > 0 ? sec : 1.0));
+    if (args.hasExpectedRgb)
+    {
+        printf("[pixel-verification] expected=%.4f,%.4f,%.4f tolerance=%.4f matching=%d/%d status=%s\n",
+               args.expectedRgb[0], args.expectedRgb[1], args.expectedRgb[2],
+               args.tolerance, matchingSamples, captured,
+               matchingSamples > 0 ? "PASS" : "FAIL");
+    }
 
     UnmapViewOfFile(meta);
     CloseHandle(hMeta);
     CloseHandle(hEvent);
-    return captured > 0 ? 0 : 1;
+    return captured > 0 && (!args.hasExpectedRgb || matchingSamples > 0) ? 0 : 1;
 }

--- a/tools/vdd_command/README.md
+++ b/tools/vdd_command/README.md
@@ -1,0 +1,22 @@
+# VDD command utility
+
+`vdd_command` sends UTF-16 commands through the ZakoVDD IOCTL device
+interface. It falls back to the administrator-only legacy pipe for older
+installed driver builds.
+
+```cmd
+build\vdd_command.exe CREATEMONITOR
+build\vdd_command.exe DESTROYMONITOR
+build\vdd_command.exe HDR-ON \\.\DISPLAY7
+build\vdd_command.exe HDR-OFF \\.\DISPLAY7
+build\vdd_command.exe DISPLAY-LIST-ALL
+build\vdd_command.exe DISPLAY-ACTIVATE-ZAKO
+```
+
+The HDR commands use Windows DisplayConfig directly and verify the effective
+state after setting it. They do not send an HDR toggle to the driver.
+
+`DISPLAY-LIST-ALL` prints active and inactive DisplayConfig paths, including
+adapter/source/target IDs and monitor identity. `DISPLAY-ACTIVATE-ZAKO` keeps
+the current active paths and adds the first connected `ZAK2333` target. The
+latter can require elevation when Windows persists the topology.

--- a/tools/vdd_command/build.bat
+++ b/tools/vdd_command/build.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+if not exist build mkdir build
+cl /nologo /std:c++17 /EHsc /W4 /O2 /DUNICODE /D_UNICODE /Fo:build\ /Fe:build\vdd_command.exe ^
+   vdd_command.cpp setupapi.lib user32.lib
+exit /b %ERRORLEVEL%

--- a/tools/vdd_command/build_consumer.bat
+++ b/tools/vdd_command/build_consumer.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (echo vcvars64 failed & exit /b 1)
+call "%~dp0build.bat"
+exit /b %ERRORLEVEL%

--- a/tools/vdd_command/vdd_command.cpp
+++ b/tools/vdd_command/vdd_command.cpp
@@ -1,0 +1,333 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <setupapi.h>
+
+#include "../../Common/Include/vdd_control_ioctl.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#pragma comment(lib, "setupapi.lib")
+
+namespace {
+
+struct Handle {
+  HANDLE value {INVALID_HANDLE_VALUE};
+  ~Handle() { if (value != INVALID_HANDLE_VALUE) CloseHandle(value); }
+};
+
+struct DeviceInfoSet {
+  HDEVINFO value {INVALID_HANDLE_VALUE};
+  ~DeviceInfoSet() { if (value != INVALID_HANDLE_VALUE) SetupDiDestroyDeviceInfoList(value); }
+};
+
+bool open_control_device(Handle& output, std::wstring& path, DWORD& native_error) {
+  const GUID interface_guid = ZAKO_VDD_CONTROL_GUID_INIT;
+  DeviceInfoSet devices;
+  devices.value = SetupDiGetClassDevsW(&interface_guid, nullptr, nullptr, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+  if (devices.value == INVALID_HANDLE_VALUE) {
+    native_error = GetLastError();
+    return false;
+  }
+
+  for (DWORD index = 0;; ++index) {
+    SP_DEVICE_INTERFACE_DATA interface_data {};
+    interface_data.cbSize = sizeof(interface_data);
+    if (!SetupDiEnumDeviceInterfaces(devices.value, nullptr, &interface_guid, index, &interface_data)) {
+      native_error = GetLastError();
+      return false;
+    }
+    DWORD required = 0;
+    SetupDiGetDeviceInterfaceDetailW(devices.value, &interface_data, nullptr, 0, &required, nullptr);
+    if (required < sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W)) continue;
+    std::vector<BYTE> storage(required);
+    auto* detail = reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA_W*>(storage.data());
+    detail->cbSize = sizeof(*detail);
+    if (!SetupDiGetDeviceInterfaceDetailW(devices.value, &interface_data, detail, required, nullptr, nullptr)) {
+      native_error = GetLastError();
+      continue;
+    }
+    Handle candidate;
+    candidate.value = CreateFileW(detail->DevicePath, GENERIC_READ | GENERIC_WRITE,
+                                  FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+    if (candidate.value == INVALID_HANDLE_VALUE) {
+      native_error = GetLastError();
+      continue;
+    }
+    path = detail->DevicePath;
+    output.value = candidate.value;
+    candidate.value = INVALID_HANDLE_VALUE;
+    return true;
+  }
+}
+
+bool send_legacy_pipe_command(const std::wstring& command, DWORD& native_error) {
+  constexpr wchar_t kPipePath[] = L"\\\\.\\pipe\\ZakoVDDPipe";
+  if (!WaitNamedPipeW(kPipePath, 3000)) {
+    native_error = GetLastError();
+    return false;
+  }
+  Handle pipe;
+  pipe.value = CreateFileW(kPipePath, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+  if (pipe.value == INVALID_HANDLE_VALUE) {
+    native_error = GetLastError();
+    return false;
+  }
+  DWORD written = 0;
+  const DWORD bytes = static_cast<DWORD>(command.size() * sizeof(wchar_t));
+  if (!WriteFile(pipe.value, command.data(), bytes, &written, nullptr) || written != bytes) {
+    native_error = GetLastError();
+    return false;
+  }
+  FlushFileBuffers(pipe.value);
+  return true;
+}
+
+bool target_hdr_enabled(const DISPLAYCONFIG_PATH_INFO& path) {
+  struct AdvancedColorInfo2 {
+    DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+    union {
+      struct {
+        UINT32 advancedColorSupported : 1;
+        UINT32 advancedColorActive : 1;
+        UINT32 reserved1 : 1;
+        UINT32 advancedColorLimitedByPolicy : 1;
+        UINT32 highDynamicRangeSupported : 1;
+        UINT32 highDynamicRangeUserEnabled : 1;
+        UINT32 wideColorSupported : 1;
+        UINT32 wideColorUserEnabled : 1;
+        UINT32 reserved : 24;
+      } bits;
+      UINT32 value;
+    } state;
+    DISPLAYCONFIG_COLOR_ENCODING colorEncoding;
+    UINT32 bitsPerColorChannel;
+    UINT32 activeColorMode;
+  } info2 {};
+  info2.header.type = static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(15);
+  info2.header.size = sizeof(info2);
+  info2.header.adapterId = path.targetInfo.adapterId;
+  info2.header.id = path.targetInfo.id;
+  if (DisplayConfigGetDeviceInfo(&info2.header) == ERROR_SUCCESS) return info2.state.bits.highDynamicRangeUserEnabled != 0;
+
+  DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO info1 {};
+  info1.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+  info1.header.size = sizeof(info1);
+  info1.header.adapterId = path.targetInfo.adapterId;
+  info1.header.id = path.targetInfo.id;
+  return DisplayConfigGetDeviceInfo(&info1.header) == ERROR_SUCCESS && info1.advancedColorEnabled != 0;
+}
+
+bool set_display_hdr(const std::wstring& gdi_name, bool enabled, LONG& native_error) {
+  UINT32 path_count = 0;
+  UINT32 mode_count = 0;
+  native_error = GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count);
+  if (native_error != ERROR_SUCCESS) return false;
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths(path_count);
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes(mode_count);
+  native_error = QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, paths.data(), &mode_count, modes.data(), nullptr);
+  if (native_error != ERROR_SUCCESS) return false;
+
+  for (UINT32 index = 0; index < path_count; ++index) {
+    DISPLAYCONFIG_SOURCE_DEVICE_NAME source {};
+    source.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+    source.header.size = sizeof(source);
+    source.header.adapterId = paths[index].sourceInfo.adapterId;
+    source.header.id = paths[index].sourceInfo.id;
+    if (DisplayConfigGetDeviceInfo(&source.header) != ERROR_SUCCESS ||
+        _wcsicmp(source.viewGdiDeviceName, gdi_name.c_str()) != 0) continue;
+
+    DISPLAYCONFIG_SET_ADVANCED_COLOR_STATE state {};
+    state.header.type = DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE;
+    state.header.size = sizeof(state);
+    state.header.adapterId = paths[index].targetInfo.adapterId;
+    state.header.id = paths[index].targetInfo.id;
+    state.enableAdvancedColor = enabled ? 1 : 0;
+    native_error = DisplayConfigSetDeviceInfo(&state.header);
+    if (native_error == ERROR_SUCCESS) return true;
+    // Some Windows builds apply the per-user advanced-color transition but
+    // return access denied while attempting to persist an adapter-level part
+    // of the request. Treat the operation as successful only after querying
+    // the effective target state back from DisplayConfig.
+    if (target_hdr_enabled(paths[index]) == enabled) {
+      native_error = ERROR_SUCCESS;
+      return true;
+    }
+    return false;
+  }
+  native_error = ERROR_NOT_FOUND;
+  return false;
+}
+
+bool list_all_display_paths(LONG& native_error) {
+  UINT32 path_count = 0;
+  UINT32 mode_count = 0;
+  constexpr UINT32 query_flags = QDC_ALL_PATHS | QDC_VIRTUAL_MODE_AWARE;
+  native_error = GetDisplayConfigBufferSizes(query_flags, &path_count, &mode_count);
+  if (native_error != ERROR_SUCCESS) return false;
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths(path_count);
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes(mode_count);
+  native_error = QueryDisplayConfig(query_flags, &path_count, paths.data(),
+                                    &mode_count, modes.data(), nullptr);
+  if (native_error != ERROR_SUCCESS) return false;
+
+  std::wcout << L"path_count=" << path_count << L'\n';
+  for (UINT32 index = 0; index < path_count; ++index) {
+    const auto& path = paths[index];
+    DISPLAYCONFIG_SOURCE_DEVICE_NAME source {};
+    source.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+    source.header.size = sizeof(source);
+    source.header.adapterId = path.sourceInfo.adapterId;
+    source.header.id = path.sourceInfo.id;
+    const LONG source_status = DisplayConfigGetDeviceInfo(&source.header);
+
+    DISPLAYCONFIG_TARGET_DEVICE_NAME target {};
+    target.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+    target.header.size = sizeof(target);
+    target.header.adapterId = path.targetInfo.adapterId;
+    target.header.id = path.targetInfo.id;
+    const LONG target_status = DisplayConfigGetDeviceInfo(&target.header);
+
+    std::wcout << L"path[" << index << L"].active="
+               << ((path.flags & DISPLAYCONFIG_PATH_ACTIVE) ? 1 : 0)
+               << L" adapter=" << path.sourceInfo.adapterId.HighPart << L":"
+               << std::hex << path.sourceInfo.adapterId.LowPart << std::dec
+               << L" source_id=" << path.sourceInfo.id
+               << L" target_id=" << path.targetInfo.id
+               << L" source=" << (source_status == ERROR_SUCCESS ? source.viewGdiDeviceName : L"<inactive>")
+               << L" monitor=" << (target_status == ERROR_SUCCESS ? target.monitorFriendlyDeviceName : L"<unknown>")
+               << L" device_path=" << (target_status == ERROR_SUCCESS ? target.monitorDevicePath : L"<unknown>")
+               << L'\n';
+  }
+  return true;
+}
+
+bool activate_zako_display(LONG& native_error) {
+  UINT32 path_count = 0;
+  UINT32 mode_count = 0;
+  native_error = GetDisplayConfigBufferSizes(QDC_ALL_PATHS, &path_count, &mode_count);
+  if (native_error != ERROR_SUCCESS) return false;
+  std::vector<DISPLAYCONFIG_PATH_INFO> all_paths(path_count);
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes(mode_count);
+  native_error = QueryDisplayConfig(QDC_ALL_PATHS, &path_count, all_paths.data(),
+                                    &mode_count, modes.data(), nullptr);
+  if (native_error != ERROR_SUCCESS) return false;
+
+  std::vector<DISPLAYCONFIG_PATH_INFO> selected;
+  DISPLAYCONFIG_PATH_INFO zako_path {};
+  bool found_zako = false;
+  for (UINT32 index = 0; index < path_count; ++index) {
+    auto path = all_paths[index];
+    if (path.flags & DISPLAYCONFIG_PATH_ACTIVE) selected.push_back(path);
+
+    DISPLAYCONFIG_TARGET_DEVICE_NAME target {};
+    target.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+    target.header.size = sizeof(target);
+    target.header.adapterId = path.targetInfo.adapterId;
+    target.header.id = path.targetInfo.id;
+    if (!found_zako && DisplayConfigGetDeviceInfo(&target.header) == ERROR_SUCCESS &&
+        (wcsstr(target.monitorDevicePath, L"ZAK2333") != nullptr ||
+         wcsstr(target.monitorFriendlyDeviceName, L"Zako") != nullptr)) {
+      zako_path = path;
+      found_zako = true;
+    }
+  }
+  if (!found_zako) {
+    native_error = ERROR_NOT_FOUND;
+    return false;
+  }
+  if (!(zako_path.flags & DISPLAYCONFIG_PATH_ACTIVE)) selected.push_back(zako_path);
+
+  for (auto& path : selected) {
+    path.flags |= DISPLAYCONFIG_PATH_ACTIVE;
+    path.sourceInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+    path.targetInfo.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+  }
+  const UINT32 base_flags = SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES;
+  native_error = SetDisplayConfig(static_cast<UINT32>(selected.size()), selected.data(),
+                                  0, nullptr, base_flags | SDC_VALIDATE);
+  if (native_error != ERROR_SUCCESS) return false;
+  native_error = SetDisplayConfig(static_cast<UINT32>(selected.size()), selected.data(),
+                                  0, nullptr, base_flags | SDC_APPLY | SDC_SAVE_TO_DATABASE);
+  return native_error == ERROR_SUCCESS;
+}
+
+void usage() {
+  std::cout << "Usage: vdd_command.exe <COMMAND> [arguments...]\n"
+               "       vdd_command.exe HDR-ON \\\\.\\DISPLAYn\n"
+               "       vdd_command.exe HDR-OFF \\\\.\\DISPLAYn\n"
+               "       vdd_command.exe DISPLAY-LIST-ALL\n"
+               "       vdd_command.exe DISPLAY-ACTIVATE-ZAKO\n"
+               "Example: vdd_command.exe CREATEMONITOR\n";
+}
+
+}  // namespace
+
+int wmain(int argc, wchar_t** argv) {
+  if (argc < 2) {
+    usage();
+    return 2;
+  }
+  if ((std::wstring(argv[1]) == L"HDR-ON" || std::wstring(argv[1]) == L"HDR-OFF")) {
+    if (argc != 3) {
+      usage();
+      return 2;
+    }
+    const bool enabled = std::wstring(argv[1]) == L"HDR-ON";
+    LONG native_error = ERROR_SUCCESS;
+    if (!set_display_hdr(argv[2], enabled, native_error)) {
+      std::wcerr << L"display=" << argv[2] << L" hdr=" << enabled << L" status=FAILED native_error=" << native_error << L'\n';
+      return 5;
+    }
+    std::wcout << L"display=" << argv[2] << L" hdr=" << enabled << L" status=SUCCESS\n";
+    return 0;
+  }
+  if (std::wstring(argv[1]) == L"DISPLAY-LIST-ALL") {
+    LONG native_error = ERROR_SUCCESS;
+    if (!list_all_display_paths(native_error)) {
+      std::wcerr << L"display_list_all=FAILED native_error=" << native_error << L'\n';
+      return 6;
+    }
+    return 0;
+  }
+  if (std::wstring(argv[1]) == L"DISPLAY-ACTIVATE-ZAKO") {
+    LONG native_error = ERROR_SUCCESS;
+    if (!activate_zako_display(native_error)) {
+      std::wcerr << L"display_activate_zako=FAILED native_error=" << native_error << L'\n';
+      return 7;
+    }
+    std::wcout << L"display_activate_zako=SUCCESS\n";
+    return 0;
+  }
+  std::wstring command = argv[1];
+  for (int index = 2; index < argc; ++index) {
+    command.push_back(L' ');
+    command.append(argv[index]);
+  }
+
+  Handle device;
+  std::wstring path;
+  DWORD native_error = ERROR_SUCCESS;
+  if (!open_control_device(device, path, native_error)) {
+    const DWORD interface_error = native_error;
+    if (!send_legacy_pipe_command(command, native_error)) {
+      std::wcerr << L"open_control_device=FAILED native_error=" << interface_error
+                 << L" legacy_pipe=FAILED native_error=" << native_error << L'\n';
+      return 3;
+    }
+    std::wcout << L"transport=legacy_pipe command=" << command << L" status=SUCCESS\n";
+    return 0;
+  }
+
+  DWORD returned = 0;
+  const DWORD bytes = static_cast<DWORD>((command.size() + 1) * sizeof(wchar_t));
+  const BOOL ok = DeviceIoControl(device.value, IOCTL_VDD_COMMAND,
+                                  command.data(), bytes, nullptr, 0, &returned, nullptr);
+  if (!ok) {
+    std::wcerr << L"command=FAILED native_error=" << GetLastError() << L'\n';
+    return 4;
+  }
+  std::wcout << L"device=" << path << L'\n' << L"command=" << command << L" status=SUCCESS\n";
+  return 0;
+}

--- a/tools/vulkan_hdr_bridge/README.md
+++ b/tools/vulkan_hdr_bridge/README.md
@@ -1,0 +1,43 @@
+# Zako Vulkan HDR bridge
+
+This is an enumeration-only Vulkan HDR WSI bridge. It is intentionally not
+installed or registered globally by the VDD package. The streaming host owns
+session-scoped registration and cleanup.
+
+The bridge injects the HDR10 and scRGB format/color-space pairs only when:
+
+- the Vulkan surface maps to a Win32 window;
+- that window is on a display identified as ZakoVDD;
+- Windows reports HDR as supported and enabled; and
+- the GPU/driver/Windows capability cache contains a verified entry.
+
+It compares complete `(format, colorSpace)` pairs and is otherwise a strict
+pass-through layer. `DISABLE_ZAKO_VIRTUAL_HDR=1` disables it through the
+standard implicit-layer manifest switch.
+
+The bridge reads `%LOCALAPPDATA%\Sunshine\zako_vulkan_hdr_capabilities.bin`
+by default, falling back to the DLL directory when `LOCALAPPDATA` is absent.
+Override that location with `ZAKO_VHDR_CAPABILITY_CACHE`. Entries are keyed by
+Vulkan vendor/device IDs, driver/API version, adapter LUID, and Windows build.
+
+Development-only overrides:
+
+- `ZAKO_VHDR_ALLOW_ANY_HDR=1` permits any active HDR display.
+- `ZAKO_VHDR_FORCE_SURFACE=1` bypasses display checks but still requires a
+  matching cache entry.
+- `ZAKO_VHDR_FORCE=1` bypasses display identity and HDR-state checks.
+
+Local closure on AMD Radeon 780M / Windows build 26200 established that:
+
+- the raw ICD returned five SDR pairs;
+- the bridge returned seven pairs including exact HDR10 and scRGB pairs;
+- a scRGB swapchain presented 600 frames successfully; and
+- the VDD RGBA16F channel read a requested `(0, 12.5, 0)` patch as
+  `(0.0083, 12.4531, 0.0073)` on three consecutive frames.
+
+Foundation Sunshine now packages all three artifacts, validates presentation,
+uses session-scoped per-user registration, cleans normal and crashed sessions,
+and exposes Automatic/Disabled plus live status in WebUI.
+
+The minimal local Vulkan ABI should be replaced by pinned Khronos
+Vulkan-Headers before broad distribution.

--- a/tools/vulkan_hdr_bridge/VkLayer_zako_virtual_hdr.json
+++ b/tools/vulkan_hdr_bridge/VkLayer_zako_virtual_hdr.json
@@ -1,0 +1,17 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+    "name": "VK_LAYER_ZAKO_virtual_hdr",
+    "type": "GLOBAL",
+    "library_path": ".\\zako_vulkan_hdr_bridge.dll",
+    "api_version": "1.1.0",
+    "implementation_version": "1",
+    "description": "Expose verified HDR WSI formats on active ZakoVDD HDR displays",
+    "functions": {
+      "vkGetInstanceProcAddr": "vkGetInstanceProcAddr"
+    },
+    "disable_environment": {
+      "DISABLE_ZAKO_VIRTUAL_HDR": "1"
+    }
+  }
+}

--- a/tools/vulkan_hdr_bridge/build.bat
+++ b/tools/vulkan_hdr_bridge/build.bat
@@ -1,0 +1,11 @@
+@echo off
+rem Experimental bridge build. Do not register system-wide before probe validation.
+setlocal
+cd /d "%~dp0"
+if not exist build mkdir build
+cl /nologo /std:c++17 /EHsc /W4 /O2 /LD /DUNICODE /D_UNICODE /Fo:build\ /Fe:build\zako_vulkan_hdr_bridge.dll ^
+   vulkan_hdr_bridge.cpp ^
+   user32.lib
+if errorlevel 1 exit /b %ERRORLEVEL%
+copy /y VkLayer_zako_virtual_hdr.json build\VkLayer_zako_virtual_hdr.json >nul
+exit /b 0

--- a/tools/vulkan_hdr_bridge/build_consumer.bat
+++ b/tools/vulkan_hdr_bridge/build_consumer.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (echo vcvars64 failed & exit /b 1)
+call "%~dp0build.bat"
+exit /b %ERRORLEVEL%

--- a/tools/vulkan_hdr_bridge/vulkan_hdr_bridge.cpp
+++ b/tools/vulkan_hdr_bridge/vulkan_hdr_bridge.cpp
@@ -1,0 +1,413 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include "../vulkan_hdr_probe/vulkan_minimal.h"
+#include "../../Common/Include/vulkan_hdr_capability_cache.h"
+#include "../../Common/Include/vulkan_hdr_policy.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <cwctype>
+#include <filesystem>
+#include <iterator>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+constexpr VkResult VK_ERROR_INITIALIZATION_FAILED = -3;
+constexpr VkStructureType VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR = 1000119002;
+constexpr VkStructureType VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = 47;
+constexpr std::int32_t VK_LAYER_LINK_INFO = 0;
+
+struct VkAllocationCallbacks;
+
+struct VkLayerInstanceLink {
+  VkLayerInstanceLink* pNext;
+  PFN_vkGetInstanceProcAddr pfnNextGetInstanceProcAddr;
+  PFN_vkVoidFunction pfnNextGetPhysicalDeviceProcAddr;
+};
+
+struct VkLayerInstanceCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  std::int32_t function;
+  union {
+    VkLayerInstanceLink* pLayerInfo;
+    void* other;
+  } u;
+};
+
+using PFN_vkDestroyInstance = void(VKAPI_PTR*)(VkInstance, const VkAllocationCallbacks*);
+using PFN_vkCreateInstance = VkResult(VKAPI_PTR*)(const VkInstanceCreateInfo*, const VkAllocationCallbacks*, VkInstance*);
+using PFN_vkCreateWin32SurfaceKHR = VkResult(VKAPI_PTR*)(VkInstance, const VkWin32SurfaceCreateInfoKHR*, const VkAllocationCallbacks*, VkSurfaceKHR*);
+using PFN_vkDestroySurfaceKHR = void(VKAPI_PTR*)(VkInstance, VkSurfaceKHR, const VkAllocationCallbacks*);
+
+struct InstanceDispatch {
+  PFN_vkGetInstanceProcAddr next_gipa {};
+  PFN_vkDestroyInstance destroy_instance {};
+  PFN_vkCreateWin32SurfaceKHR create_surface {};
+  PFN_vkDestroySurfaceKHR destroy_surface {};
+  PFN_vkGetPhysicalDeviceSurfaceFormatsKHR get_formats {};
+  PFN_vkGetPhysicalDeviceSurfaceFormats2KHR get_formats2 {};
+  PFN_vkGetPhysicalDeviceProperties2 get_properties2 {};
+};
+
+struct AllowedPairs {
+  bool hdr10 {};
+  bool scrgb {};
+};
+
+std::mutex g_mutex;
+std::unordered_map<void*, InstanceDispatch> g_instances;
+std::unordered_map<VkSurfaceKHR, HWND> g_surface_windows;
+
+void* dispatch_key(const void* dispatchable) {
+  return dispatchable ? *reinterpret_cast<void* const*>(dispatchable) : nullptr;
+}
+
+bool get_dispatch(const void* dispatchable, InstanceDispatch& output) {
+  const auto key = dispatch_key(dispatchable);
+  if (!key) return false;
+  std::lock_guard<std::mutex> lock(g_mutex);
+  const auto found = g_instances.find(key);
+  if (found == g_instances.end()) return false;
+  output = found->second;
+  return true;
+}
+
+bool env_enabled(const char* name) {
+  char value[8] {};
+  return GetEnvironmentVariableA(name, value, static_cast<DWORD>(sizeof(value))) > 0 && value[0] == '1';
+}
+
+std::uint32_t windows_build_number() {
+  struct VersionInfo {
+    ULONG size;
+    ULONG major;
+    ULONG minor;
+    ULONG build;
+    ULONG platform;
+    WCHAR service_pack[128];
+  } version {sizeof(VersionInfo)};
+  using RtlGetVersionFn = LONG(WINAPI*)(VersionInfo*);
+  const auto ntdll = GetModuleHandleW(L"ntdll.dll");
+  const auto rtl_get_version = ntdll ? reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdll, "RtlGetVersion")) : nullptr;
+  return rtl_get_version && rtl_get_version(&version) == 0 ? version.build : 0;
+}
+
+std::wstring capability_cache_path() {
+  wchar_t override_path[32768] {};
+  const DWORD override_length = GetEnvironmentVariableW(L"ZAKO_VHDR_CAPABILITY_CACHE", override_path,
+                                                         static_cast<DWORD>(std::size(override_path)));
+  if (override_length > 0 && override_length < std::size(override_path)) return override_path;
+
+  wchar_t local_app_data[32768] {};
+  const DWORD local_app_data_length = GetEnvironmentVariableW(L"LOCALAPPDATA", local_app_data,
+                                                               static_cast<DWORD>(std::size(local_app_data)));
+  if (local_app_data_length > 0 && local_app_data_length < std::size(local_app_data)) {
+    return (std::filesystem::path(local_app_data) / L"Sunshine" /
+            L"zako_vulkan_hdr_capabilities.bin").wstring();
+  }
+
+  HMODULE module = nullptr;
+  if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCWSTR>(&capability_cache_path), &module)) return {};
+  wchar_t module_path[32768] {};
+  const DWORD length = GetModuleFileNameW(module, module_path, static_cast<DWORD>(std::size(module_path)));
+  if (length == 0 || length >= std::size(module_path)) return {};
+  return (std::filesystem::path(module_path).parent_path() / L"zako_vulkan_hdr_capabilities.bin").wstring();
+}
+
+AllowedPairs verified_pairs(VkPhysicalDevice device, const InstanceDispatch& dispatch) {
+  if (env_enabled("ZAKO_VHDR_FORCE")) return {true, true};
+  if (!dispatch.get_properties2) return {};
+
+  VkPhysicalDeviceIDProperties id {};
+  id.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+  VkPhysicalDeviceProperties2Probe properties {};
+  properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  properties.pNext = &id;
+  dispatch.get_properties2(device, &properties);
+
+  zako::vulkan_hdr::CapabilityCacheEntry key {};
+  key.vendor_id = properties.properties.vendorID;
+  key.device_id = properties.properties.deviceID;
+  key.driver_version = properties.properties.driverVersion;
+  key.api_version = properties.properties.apiVersion;
+  key.windows_build = windows_build_number();
+  if (id.deviceLUIDValid) {
+    std::memcpy(&key.adapter_luid_low, id.deviceLUID, sizeof(key.adapter_luid_low));
+    std::memcpy(&key.adapter_luid_high, id.deviceLUID + sizeof(key.adapter_luid_low), sizeof(key.adapter_luid_high));
+  }
+
+  const auto path = capability_cache_path();
+  if (path.empty()) return {};
+  const auto entries = zako::vulkan_hdr::read_capability_cache(path);
+  const auto found = std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
+    return zako::vulkan_hdr::same_capability_key(entry, key);
+  });
+  const auto required = zako::vulkan_hdr::kCapabilityValidatedWhileHdrActive |
+                        zako::vulkan_hdr::kCapabilityPresented;
+  if (found == entries.end() || (found->flags & required) != required) return {};
+  return {(found->flags & zako::vulkan_hdr::kCapabilityHdr10Swapchain) != 0,
+          (found->flags & zako::vulkan_hdr::kCapabilityScRgbSwapchain) != 0};
+}
+
+std::wstring lowercase(std::wstring value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](wchar_t c) { return static_cast<wchar_t>(std::towlower(c)); });
+  return value;
+}
+
+bool looks_like_zako_target(const DISPLAYCONFIG_TARGET_DEVICE_NAME& target) {
+  const auto friendly = lowercase(target.monitorFriendlyDeviceName);
+  const auto path = lowercase(target.monitorDevicePath);
+  return friendly.find(L"zako") != std::wstring::npos ||
+         path.find(L"zakovdd") != std::wstring::npos ||
+         path.find(L"#zak") != std::wstring::npos;
+}
+
+bool target_hdr_enabled(const DISPLAYCONFIG_PATH_INFO& path) {
+  struct AdvancedColorInfo2 {
+    DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+    union {
+      struct {
+        UINT32 advancedColorSupported : 1;
+        UINT32 advancedColorActive : 1;
+        UINT32 reserved1 : 1;
+        UINT32 advancedColorLimitedByPolicy : 1;
+        UINT32 highDynamicRangeSupported : 1;
+        UINT32 highDynamicRangeUserEnabled : 1;
+        UINT32 wideColorSupported : 1;
+        UINT32 wideColorUserEnabled : 1;
+        UINT32 reserved : 24;
+      } bits;
+      UINT32 value;
+    } state;
+    DISPLAYCONFIG_COLOR_ENCODING colorEncoding;
+    UINT32 bitsPerColorChannel;
+    UINT32 activeColorMode;
+  } info2 {};
+  info2.header.type = static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(15);
+  info2.header.size = sizeof(info2);
+  info2.header.adapterId = path.targetInfo.adapterId;
+  info2.header.id = path.targetInfo.id;
+  if (DisplayConfigGetDeviceInfo(&info2.header) == ERROR_SUCCESS) {
+    return info2.state.bits.highDynamicRangeSupported && info2.state.bits.highDynamicRangeUserEnabled;
+  }
+
+  DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO info1 {};
+  info1.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+  info1.header.size = sizeof(info1);
+  info1.header.adapterId = path.targetInfo.adapterId;
+  info1.header.id = path.targetInfo.id;
+  return DisplayConfigGetDeviceInfo(&info1.header) == ERROR_SUCCESS &&
+         info1.advancedColorSupported && info1.advancedColorEnabled;
+}
+
+bool should_bridge(HWND window) {
+  if (!window) return false;
+  if (env_enabled("ZAKO_VHDR_FORCE") || env_enabled("ZAKO_VHDR_FORCE_SURFACE")) return true;
+
+  const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST);
+  MONITORINFOEXW monitor_info {};
+  monitor_info.cbSize = sizeof(monitor_info);
+  if (!monitor || !GetMonitorInfoW(monitor, &monitor_info)) return false;
+
+  UINT32 path_count = 0;
+  UINT32 mode_count = 0;
+  if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count) != ERROR_SUCCESS) return false;
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths(path_count);
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes(mode_count);
+  if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, paths.data(), &mode_count, modes.data(), nullptr) != ERROR_SUCCESS) return false;
+
+  for (UINT32 index = 0; index < path_count; ++index) {
+    DISPLAYCONFIG_SOURCE_DEVICE_NAME source {};
+    source.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+    source.header.size = sizeof(source);
+    source.header.adapterId = paths[index].sourceInfo.adapterId;
+    source.header.id = paths[index].sourceInfo.id;
+    if (DisplayConfigGetDeviceInfo(&source.header) != ERROR_SUCCESS ||
+        std::wcscmp(source.viewGdiDeviceName, monitor_info.szDevice) != 0) continue;
+
+    DISPLAYCONFIG_TARGET_DEVICE_NAME target {};
+    target.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+    target.header.size = sizeof(target);
+    target.header.adapterId = paths[index].targetInfo.adapterId;
+    target.header.id = paths[index].targetInfo.id;
+    if (DisplayConfigGetDeviceInfo(&target.header) != ERROR_SUCCESS) return false;
+    if (!env_enabled("ZAKO_VHDR_ALLOW_ANY_HDR") && !looks_like_zako_target(target)) return false;
+    return target_hdr_enabled(paths[index]);
+  }
+  return false;
+}
+
+bool should_bridge_surface(VkSurfaceKHR surface) {
+  HWND window = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    const auto found = g_surface_windows.find(surface);
+    if (found == g_surface_windows.end()) return false;
+    window = found->second;
+  }
+  return should_bridge(window);
+}
+
+void append_verified_pairs(std::vector<VkSurfaceFormatKHR>& formats, AllowedPairs allowed) {
+  std::vector<zako::vulkan_hdr::FormatPair> pairs;
+  pairs.reserve(formats.size() + 2);
+  for (const auto& entry : formats) pairs.push_back({entry.format, entry.colorSpace});
+  zako::vulkan_hdr::append_missing_verified_pairs(pairs, allowed.hdr10, allowed.scrgb);
+  formats.clear();
+  formats.reserve(pairs.size());
+  for (const auto& pair : pairs) formats.push_back({pair.format, pair.color_space});
+}
+
+VkResult VKAPI_PTR layer_create_surface(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* info,
+                                        const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface) {
+  InstanceDispatch dispatch;
+  if (!info || !surface || !get_dispatch(instance, dispatch) || !dispatch.create_surface) return VK_ERROR_INITIALIZATION_FAILED;
+  const VkResult result = dispatch.create_surface(instance, info, allocator, surface);
+  if (result == VK_SUCCESS) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_surface_windows[*surface] = static_cast<HWND>(info->hwnd);
+  }
+  return result;
+}
+
+void VKAPI_PTR layer_destroy_surface(VkInstance instance, VkSurfaceKHR surface, const VkAllocationCallbacks* allocator) {
+  InstanceDispatch dispatch;
+  const bool have_dispatch = get_dispatch(instance, dispatch);
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_surface_windows.erase(surface);
+  }
+  if (have_dispatch && dispatch.destroy_surface) dispatch.destroy_surface(instance, surface, allocator);
+}
+
+VkResult VKAPI_PTR layer_get_formats(VkPhysicalDevice device, VkSurfaceKHR surface, std::uint32_t* count,
+                                     VkSurfaceFormatKHR* output) {
+  InstanceDispatch dispatch;
+  if (!count || !get_dispatch(device, dispatch) || !dispatch.get_formats) return VK_ERROR_INITIALIZATION_FAILED;
+  if (!should_bridge_surface(surface)) return dispatch.get_formats(device, surface, count, output);
+  const auto allowed = verified_pairs(device, dispatch);
+  if (!allowed.hdr10 && !allowed.scrgb) return dispatch.get_formats(device, surface, count, output);
+
+  std::uint32_t base_count = 0;
+  VkResult result = dispatch.get_formats(device, surface, &base_count, nullptr);
+  if (result != VK_SUCCESS) return dispatch.get_formats(device, surface, count, output);
+  std::vector<VkSurfaceFormatKHR> formats(base_count);
+  result = dispatch.get_formats(device, surface, &base_count, formats.data());
+  if (result != VK_SUCCESS && result != VK_INCOMPLETE) return dispatch.get_formats(device, surface, count, output);
+  formats.resize(base_count);
+  append_verified_pairs(formats, allowed);
+
+  if (!output) {
+    *count = static_cast<std::uint32_t>(formats.size());
+    return VK_SUCCESS;
+  }
+  const auto total = static_cast<std::uint32_t>(formats.size());
+  const auto copied = std::min(*count, total);
+  std::memcpy(output, formats.data(), copied * sizeof(VkSurfaceFormatKHR));
+  *count = copied;
+  return copied < total ? VK_INCOMPLETE : VK_SUCCESS;
+}
+
+VkResult VKAPI_PTR layer_get_formats2(VkPhysicalDevice device, const VkPhysicalDeviceSurfaceInfo2KHR* surface_info,
+                                      std::uint32_t* count, VkSurfaceFormat2KHR* output) {
+  InstanceDispatch dispatch;
+  if (!count || !get_dispatch(device, dispatch) || !dispatch.get_formats2) return VK_ERROR_INITIALIZATION_FAILED;
+  if (!surface_info || !should_bridge_surface(surface_info->surface)) return dispatch.get_formats2(device, surface_info, count, output);
+  const auto allowed = verified_pairs(device, dispatch);
+  if (!allowed.hdr10 && !allowed.scrgb) return dispatch.get_formats2(device, surface_info, count, output);
+
+  std::uint32_t base_count = 0;
+  VkResult result = dispatch.get_formats2(device, surface_info, &base_count, nullptr);
+  if (result != VK_SUCCESS) return dispatch.get_formats2(device, surface_info, count, output);
+  std::vector<VkSurfaceFormat2KHR> base(base_count);
+  for (auto& entry : base) {
+    entry.sType = VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR;
+    entry.pNext = nullptr;
+  }
+  result = dispatch.get_formats2(device, surface_info, &base_count, base.data());
+  if (result != VK_SUCCESS && result != VK_INCOMPLETE) return dispatch.get_formats2(device, surface_info, count, output);
+  std::vector<VkSurfaceFormatKHR> formats;
+  formats.reserve(base_count + 2);
+  for (std::uint32_t index = 0; index < base_count; ++index) formats.push_back(base[index].surfaceFormat);
+  append_verified_pairs(formats, allowed);
+
+  if (!output) {
+    *count = static_cast<std::uint32_t>(formats.size());
+    return VK_SUCCESS;
+  }
+  const auto total = static_cast<std::uint32_t>(formats.size());
+  const auto copied = std::min(*count, total);
+  for (std::uint32_t index = 0; index < copied; ++index) output[index].surfaceFormat = formats[index];
+  *count = copied;
+  return copied < total ? VK_INCOMPLETE : VK_SUCCESS;
+}
+
+void VKAPI_PTR layer_destroy_instance(VkInstance instance, const VkAllocationCallbacks* allocator) {
+  PFN_vkDestroyInstance next = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    const auto found = g_instances.find(dispatch_key(instance));
+    if (found != g_instances.end()) {
+      next = found->second.destroy_instance;
+      g_instances.erase(found);
+    }
+  }
+  if (next) next(instance, allocator);
+}
+
+VkResult VKAPI_PTR layer_create_instance(const VkInstanceCreateInfo* create_info,
+                                         const VkAllocationCallbacks* allocator, VkInstance* instance) {
+  if (!create_info || !instance) return VK_ERROR_INITIALIZATION_FAILED;
+  auto* chain = const_cast<VkLayerInstanceCreateInfo*>(reinterpret_cast<const VkLayerInstanceCreateInfo*>(create_info->pNext));
+  while (chain && !(chain->sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO && chain->function == VK_LAYER_LINK_INFO)) {
+    chain = const_cast<VkLayerInstanceCreateInfo*>(reinterpret_cast<const VkLayerInstanceCreateInfo*>(chain->pNext));
+  }
+  if (!chain || !chain->u.pLayerInfo) return VK_ERROR_INITIALIZATION_FAILED;
+  const auto next_gipa = chain->u.pLayerInfo->pfnNextGetInstanceProcAddr;
+  chain->u.pLayerInfo = chain->u.pLayerInfo->pNext;
+  const auto next_create = reinterpret_cast<PFN_vkCreateInstance>(next_gipa(nullptr, "vkCreateInstance"));
+  if (!next_create) return VK_ERROR_INITIALIZATION_FAILED;
+  const VkResult result = next_create(create_info, allocator, instance);
+  if (result != VK_SUCCESS) return result;
+
+  InstanceDispatch dispatch {};
+  dispatch.next_gipa = next_gipa;
+  dispatch.destroy_instance = reinterpret_cast<PFN_vkDestroyInstance>(next_gipa(*instance, "vkDestroyInstance"));
+  dispatch.create_surface = reinterpret_cast<PFN_vkCreateWin32SurfaceKHR>(next_gipa(*instance, "vkCreateWin32SurfaceKHR"));
+  dispatch.destroy_surface = reinterpret_cast<PFN_vkDestroySurfaceKHR>(next_gipa(*instance, "vkDestroySurfaceKHR"));
+  dispatch.get_formats = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>(next_gipa(*instance, "vkGetPhysicalDeviceSurfaceFormatsKHR"));
+  dispatch.get_formats2 = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>(next_gipa(*instance, "vkGetPhysicalDeviceSurfaceFormats2KHR"));
+  dispatch.get_properties2 = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(next_gipa(*instance, "vkGetPhysicalDeviceProperties2"));
+  if (!dispatch.get_properties2) {
+    dispatch.get_properties2 = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2>(next_gipa(*instance, "vkGetPhysicalDeviceProperties2KHR"));
+  }
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_instances[dispatch_key(*instance)] = dispatch;
+  }
+  return VK_SUCCESS;
+}
+
+}  // namespace
+
+extern "C" __declspec(dllexport) PFN_vkVoidFunction VKAPI_PTR vkGetInstanceProcAddr(VkInstance instance, const char* name) {
+  if (!name) return nullptr;
+  if (std::strcmp(name, "vkGetInstanceProcAddr") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&vkGetInstanceProcAddr);
+  if (std::strcmp(name, "vkCreateInstance") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_create_instance);
+  if (std::strcmp(name, "vkDestroyInstance") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_destroy_instance);
+  if (std::strcmp(name, "vkCreateWin32SurfaceKHR") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_create_surface);
+  if (std::strcmp(name, "vkDestroySurfaceKHR") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_destroy_surface);
+  if (std::strcmp(name, "vkGetPhysicalDeviceSurfaceFormatsKHR") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_get_formats);
+  if (std::strcmp(name, "vkGetPhysicalDeviceSurfaceFormats2KHR") == 0) return reinterpret_cast<PFN_vkVoidFunction>(&layer_get_formats2);
+  InstanceDispatch dispatch;
+  return instance && get_dispatch(instance, dispatch) && dispatch.next_gipa ? dispatch.next_gipa(instance, name) : nullptr;
+}

--- a/tools/vulkan_hdr_policy_test/build.bat
+++ b/tools/vulkan_hdr_policy_test/build.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+if not exist build mkdir build
+cl /nologo /std:c++17 /EHsc /W4 /O2 /Fo:build\ /Fe:build\vulkan_hdr_policy_test.exe vulkan_hdr_policy_test.cpp
+if errorlevel 1 exit /b %ERRORLEVEL%
+build\vulkan_hdr_policy_test.exe
+exit /b %ERRORLEVEL%

--- a/tools/vulkan_hdr_policy_test/build_consumer.bat
+++ b/tools/vulkan_hdr_policy_test/build_consumer.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (echo vcvars64 failed & exit /b 1)
+call "%~dp0build.bat"
+exit /b %ERRORLEVEL%

--- a/tools/vulkan_hdr_policy_test/vulkan_hdr_policy_test.cpp
+++ b/tools/vulkan_hdr_policy_test/vulkan_hdr_policy_test.cpp
@@ -1,0 +1,37 @@
+#include "../../Common/Include/vulkan_hdr_policy.h"
+#include "../../Common/Include/vulkan_hdr_capability_cache.h"
+
+#include <iostream>
+#include <vector>
+#include <cstdio>
+
+int main() {
+  using namespace zako::vulkan_hdr;
+  std::vector<FormatPair> formats {{64, 0}, {44, 0}, {12, 1000104008}};
+  append_missing_verified_pairs(formats, true, true);
+  if (!contains_pair(formats, kHdr10Pair) || !contains_pair(formats, kScRgbPair) || formats.size() != 5) return 1;
+  append_missing_verified_pairs(formats, true, true);
+  if (formats.size() != 5) return 2;
+
+  std::vector<FormatPair> hdr10_only;
+  append_missing_verified_pairs(hdr10_only, true, false);
+  if (!contains_pair(hdr10_only, kHdr10Pair) || contains_pair(hdr10_only, kScRgbPair)) return 3;
+
+  CapabilityCacheEntry entry {};
+  entry.vendor_id = 0x10de;
+  entry.device_id = 0x2684;
+  entry.driver_version = 123;
+  entry.api_version = 456;
+  entry.adapter_luid_low = 789;
+  entry.windows_build = 26100;
+  entry.flags = kCapabilityHdr10Swapchain | kCapabilityValidatedWhileHdrActive;
+  std::vector<CapabilityCacheEntry> cache;
+  upsert_capability(cache, entry);
+  const std::wstring path = L"build\\vulkan_hdr_capability_test.bin";
+  if (!write_capability_cache(path, cache)) return 4;
+  const auto loaded = read_capability_cache(path);
+  std::remove("build\\vulkan_hdr_capability_test.bin");
+  if (loaded.size() != 1 || !same_capability_key(loaded.front(), entry) || loaded.front().flags != entry.flags) return 5;
+  std::cout << "vulkan_hdr_policy_test=PASS\n";
+  return 0;
+}

--- a/tools/vulkan_hdr_probe/README.md
+++ b/tools/vulkan_hdr_probe/README.md
@@ -1,0 +1,60 @@
+# Vulkan HDR probe
+
+`vulkan_hdr_probe` diagnoses the Vulkan WSI gap seen on HDR-capable IddCx
+displays. It only modifies system state for explicit cache-writing or
+per-user implicit-layer registration commands.
+
+Build from an x64 Visual Studio 2022 developer prompt:
+
+```cmd
+build.bat
+```
+
+List active displays and their HDR state:
+
+```cmd
+build\vulkan_hdr_probe.exe --list
+```
+
+Test whether the ICD accepts missing HDR10/scRGB pairs and write the keyed
+capability cache:
+
+```cmd
+build\vulkan_hdr_probe.exe --display \\.\DISPLAY2 --gpu 0 --force-create ^
+  --cache ..\vulkan_hdr_bridge\build\zako_vulkan_hdr_capabilities.bin
+```
+
+Perform real acquire/clear/submit/present work and hold a known scRGB patch for
+the VDD shared-frame consumer:
+
+```cmd
+build\vulkan_hdr_probe.exe --display \\.\DISPLAY2 --present scrgb ^
+  --frames 600 --hold-ms 30000 --clear 0 12.5 0 ^
+  --cache ..\vulkan_hdr_bridge\build\zako_vulkan_hdr_capabilities.bin
+```
+
+Inspect or mark eligible entries after external pixel verification:
+
+```cmd
+build\vulkan_hdr_probe.exe --show-cache ^
+  ..\vulkan_hdr_bridge\build\zako_vulkan_hdr_capabilities.bin
+
+build\vulkan_hdr_probe.exe --mark-pixels-verified ^
+  ..\vulkan_hdr_bridge\build\zako_vulkan_hdr_capabilities.bin
+```
+
+Register or remove the bridge for the current Windows user. Removal matches
+the manifest filename, so it also cleans paths left by an older installation:
+
+```cmd
+build\vulkan_hdr_probe.exe --register-implicit-layer C:\path\VkLayer_zako_virtual_hdr.json
+build\vulkan_hdr_probe.exe --unregister-implicit-layer VkLayer_zako_virtual_hdr.json
+```
+
+HDR10 present submits BT.2020 mastering metadata. The default HDR10 patch is
+the PQ code value for 1000 nits; the default scRGB patch is `12.5`, the Windows
+linear scRGB value corresponding to 1000 nits.
+
+The cache key includes Vulkan vendor/device IDs, driver/API versions, adapter
+LUID, and Windows build. `--mark-pixels-verified` only marks entries that
+already contain both HDR-active validation and a successful present result.

--- a/tools/vulkan_hdr_probe/build.bat
+++ b/tools/vulkan_hdr_probe/build.bat
@@ -1,0 +1,10 @@
+@echo off
+rem Build the standalone Vulkan HDR diagnostic probe using x64 MSVC.
+rem No Vulkan SDK is required; Vulkan is loaded dynamically at runtime.
+setlocal
+cd /d "%~dp0"
+if not exist build mkdir build
+cl /nologo /std:c++17 /EHsc /W4 /O2 /DUNICODE /D_UNICODE /Fo:build\ /Fe:build\vulkan_hdr_probe.exe ^
+   vulkan_hdr_probe.cpp ^
+   user32.lib advapi32.lib
+exit /b %ERRORLEVEL%

--- a/tools/vulkan_hdr_probe/build_consumer.bat
+++ b/tools/vulkan_hdr_probe/build_consumer.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set "VSINSTALL="
+for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%i"
+if not defined VSINSTALL set "VSINSTALL=C:\Program Files\Microsoft Visual Studio\2022\Community"
+call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (echo vcvars64 failed & exit /b 1)
+call "%~dp0build.bat"
+exit /b %ERRORLEVEL%

--- a/tools/vulkan_hdr_probe/vulkan_hdr_probe.cpp
+++ b/tools/vulkan_hdr_probe/vulkan_hdr_probe.cpp
@@ -1,0 +1,905 @@
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include "vulkan_minimal.h"
+#include "../../Common/Include/vulkan_hdr_capability_cache.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <cwctype>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr char kSurfaceExtension[] = "VK_KHR_surface";
+constexpr char kWin32SurfaceExtension[] = "VK_KHR_win32_surface";
+constexpr char kSwapchainColorspaceExtension[] = "VK_EXT_swapchain_colorspace";
+constexpr char kSwapchainExtension[] = "VK_KHR_swapchain";
+constexpr wchar_t kImplicitLayersKey[] = L"SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers";
+
+struct DisplayTarget {
+  std::wstring gdi_name;
+  RECT bounds {};
+  bool hdr_supported {};
+  bool hdr_enabled {};
+};
+
+struct AdvancedColorState {
+  bool supported {};
+  bool enabled {};
+};
+
+struct VulkanFunctions {
+  HMODULE module {};
+  PFN_vkGetInstanceProcAddr get_instance_proc_addr {};
+  PFN_vkEnumerateInstanceExtensionProperties enumerate_instance_extensions {};
+  PFN_vkCreateInstance create_instance {};
+  PFN_vkDestroyInstance destroy_instance {};
+  PFN_vkEnumeratePhysicalDevices enumerate_physical_devices {};
+  PFN_vkGetPhysicalDeviceProperties2 get_physical_device_properties2 {};
+  PFN_vkCreateWin32SurfaceKHR create_win32_surface {};
+  PFN_vkDestroySurfaceKHR destroy_surface {};
+  PFN_vkGetPhysicalDeviceSurfaceSupportKHR get_surface_support {};
+  PFN_vkGetPhysicalDeviceSurfaceFormatsKHR get_surface_formats {};
+  PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR get_surface_capabilities {};
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties get_queue_families {};
+  PFN_vkEnumerateDeviceExtensionProperties enumerate_device_extensions {};
+  PFN_vkCreateDevice create_device {};
+  PFN_vkGetDeviceProcAddr get_device_proc_addr {};
+  PFN_vkDestroyDevice destroy_device {};
+};
+
+struct DeviceFingerprint {
+  zako::vulkan_hdr::CapabilityCacheEntry cache_entry;
+  bool luid_valid {};
+};
+
+struct PresentTestResult {
+  VkResult swapchain_result {-3};
+  VkResult present_result {-3};
+  std::uint32_t frames_presented {};
+  bool metadata_submitted {};
+};
+
+std::string narrow(const std::wstring& value) {
+  if (value.empty()) return {};
+  const int bytes = WideCharToMultiByte(CP_UTF8, 0, value.c_str(), static_cast<int>(value.size()), nullptr, 0, nullptr, nullptr);
+  std::string result(static_cast<std::size_t>(std::max(bytes, 0)), '\0');
+  if (bytes > 0) WideCharToMultiByte(CP_UTF8, 0, value.c_str(), static_cast<int>(value.size()), result.data(), bytes, nullptr, nullptr);
+  return result;
+}
+
+AdvancedColorState query_advanced_color(const std::wstring& gdi_name) {
+  UINT32 path_count = 0;
+  UINT32 mode_count = 0;
+  if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count) != ERROR_SUCCESS) return {};
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths(path_count);
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes(mode_count);
+  if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, paths.data(), &mode_count, modes.data(), nullptr) != ERROR_SUCCESS) return {};
+
+  for (UINT32 i = 0; i < path_count; ++i) {
+    DISPLAYCONFIG_SOURCE_DEVICE_NAME source {};
+    source.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+    source.header.size = sizeof(source);
+    source.header.adapterId = paths[i].sourceInfo.adapterId;
+    source.header.id = paths[i].sourceInfo.id;
+    if (DisplayConfigGetDeviceInfo(&source.header) != ERROR_SUCCESS || gdi_name != source.viewGdiDeviceName) continue;
+
+    struct AdvancedColorInfo2 {
+      DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+      union {
+        struct {
+          UINT32 advancedColorSupported : 1;
+          UINT32 advancedColorActive : 1;
+          UINT32 reserved1 : 1;
+          UINT32 advancedColorLimitedByPolicy : 1;
+          UINT32 highDynamicRangeSupported : 1;
+          UINT32 highDynamicRangeUserEnabled : 1;
+          UINT32 wideColorSupported : 1;
+          UINT32 wideColorUserEnabled : 1;
+          UINT32 reserved : 24;
+        } bits;
+        UINT32 value;
+      } state;
+      DISPLAYCONFIG_COLOR_ENCODING colorEncoding;
+      UINT32 bitsPerColorChannel;
+      UINT32 activeColorMode;
+    } info2 {};
+    info2.header.type = static_cast<DISPLAYCONFIG_DEVICE_INFO_TYPE>(15);
+    info2.header.size = sizeof(info2);
+    info2.header.adapterId = paths[i].targetInfo.adapterId;
+    info2.header.id = paths[i].targetInfo.id;
+    if (DisplayConfigGetDeviceInfo(&info2.header) == ERROR_SUCCESS) {
+      return {info2.state.bits.highDynamicRangeSupported != 0,
+              info2.state.bits.highDynamicRangeUserEnabled != 0};
+    }
+
+    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO info1 {};
+    info1.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+    info1.header.size = sizeof(info1);
+    info1.header.adapterId = paths[i].targetInfo.adapterId;
+    info1.header.id = paths[i].targetInfo.id;
+    if (DisplayConfigGetDeviceInfo(&info1.header) == ERROR_SUCCESS) {
+      return {info1.advancedColorSupported != 0, info1.advancedColorEnabled != 0};
+    }
+  }
+  return {};
+}
+
+BOOL CALLBACK collect_monitor(HMONITOR monitor, HDC, LPRECT, LPARAM context) {
+  auto& displays = *reinterpret_cast<std::vector<DisplayTarget>*>(context);
+  MONITORINFOEXW info {};
+  info.cbSize = sizeof(info);
+  if (!GetMonitorInfoW(monitor, &info)) return TRUE;
+  const auto color = query_advanced_color(info.szDevice);
+  displays.push_back({info.szDevice, info.rcMonitor, color.supported, color.enabled});
+  return TRUE;
+}
+
+std::vector<DisplayTarget> displays() {
+  std::vector<DisplayTarget> result;
+  EnumDisplayMonitors(nullptr, nullptr, collect_monitor, reinterpret_cast<LPARAM>(&result));
+  return result;
+}
+
+LRESULT CALLBACK probe_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) {
+  return DefWindowProcW(window, message, wparam, lparam);
+}
+
+void pump_messages_for(DWORD duration_ms) {
+  const ULONGLONG deadline = GetTickCount64() + duration_ms;
+  do {
+    MSG message {};
+    while (PeekMessageW(&message, nullptr, 0, 0, PM_REMOVE)) {
+      TranslateMessage(&message);
+      DispatchMessageW(&message);
+    }
+    if (duration_ms == 0 || GetTickCount64() >= deadline) break;
+    Sleep(1);
+  } while (true);
+}
+
+HWND create_probe_window(const DisplayTarget& display) {
+  constexpr wchar_t kClassName[] = L"ZakoVulkanHdrProbeWindow";
+  WNDCLASSW wc {};
+  wc.lpfnWndProc = probe_window_proc;
+  wc.hInstance = GetModuleHandleW(nullptr);
+  wc.lpszClassName = kClassName;
+  RegisterClassW(&wc);
+  HWND window = CreateWindowExW(WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_LAYERED,
+                                kClassName, L"Zako Vulkan HDR Probe", WS_POPUP,
+                                display.bounds.left + 32, display.bounds.top + 32, 256, 256,
+                                nullptr, nullptr, wc.hInstance, nullptr);
+  if (window) SetLayeredWindowAttributes(window, 0, 254, LWA_ALPHA);
+  return window;
+}
+
+template <typename T>
+T instance_proc(const VulkanFunctions& vk, VkInstance instance, const char* name) {
+  return reinterpret_cast<T>(vk.get_instance_proc_addr(instance, name));
+}
+
+bool has_extension(const std::vector<VkExtensionProperties>& extensions, const char* name) {
+  return std::any_of(extensions.begin(), extensions.end(), [name](const auto& entry) {
+    return std::strcmp(entry.extensionName, name) == 0;
+  });
+}
+
+std::vector<VkExtensionProperties> instance_extensions(const VulkanFunctions& vk) {
+  std::uint32_t count = 0;
+  if (vk.enumerate_instance_extensions(nullptr, &count, nullptr) != VK_SUCCESS) return {};
+  std::vector<VkExtensionProperties> result(count);
+  const VkResult status = vk.enumerate_instance_extensions(nullptr, &count, result.data());
+  if (status != VK_SUCCESS && status != VK_INCOMPLETE) return {};
+  result.resize(count);
+  return result;
+}
+
+std::vector<VkExtensionProperties> device_extensions(const VulkanFunctions& vk, VkPhysicalDevice physical_device) {
+  std::uint32_t count = 0;
+  if (vk.enumerate_device_extensions(physical_device, nullptr, &count, nullptr) != VK_SUCCESS) return {};
+  std::vector<VkExtensionProperties> result(count);
+  const VkResult status = vk.enumerate_device_extensions(physical_device, nullptr, &count, result.data());
+  if (status != VK_SUCCESS && status != VK_INCOMPLETE) return {};
+  result.resize(count);
+  return result;
+}
+
+std::vector<VkSurfaceFormatKHR> surface_formats(const VulkanFunctions& vk, VkPhysicalDevice device, VkSurfaceKHR surface) {
+  std::uint32_t count = 0;
+  if (vk.get_surface_formats(device, surface, &count, nullptr) != VK_SUCCESS) return {};
+  std::vector<VkSurfaceFormatKHR> result(count);
+  const VkResult status = vk.get_surface_formats(device, surface, &count, result.data());
+  if (status != VK_SUCCESS && status != VK_INCOMPLETE) return {};
+  result.resize(count);
+  return result;
+}
+
+bool contains_pair(const std::vector<VkSurfaceFormatKHR>& formats, VkFormat format, VkColorSpaceKHR color_space) {
+  return std::any_of(formats.begin(), formats.end(), [=](const auto& entry) {
+    return entry.format == format && entry.colorSpace == color_space;
+  });
+}
+
+bool write_capability_cache_atomic(const std::wstring& path,
+                                   const std::vector<zako::vulkan_hdr::CapabilityCacheEntry>& entries) {
+  std::error_code directory_error;
+  const auto parent = std::filesystem::path(path).parent_path();
+  if (!parent.empty()) std::filesystem::create_directories(parent, directory_error);
+  if (directory_error) return false;
+  const std::wstring temporary = path + L".tmp";
+  if (!zako::vulkan_hdr::write_capability_cache(temporary, entries)) return false;
+  if (MoveFileExW(temporary.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) return true;
+  DeleteFileW(temporary.c_str());
+  return false;
+}
+
+std::wstring lowercase(std::wstring value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](wchar_t ch) {
+    return static_cast<wchar_t>(std::towlower(ch));
+  });
+  return value;
+}
+
+bool register_user_implicit_layer(const std::wstring& manifest_path) {
+  HKEY key = nullptr;
+  DWORD disposition = 0;
+  const LONG created = RegCreateKeyExW(HKEY_CURRENT_USER, kImplicitLayersKey, 0, nullptr, 0,
+                                        KEY_SET_VALUE | KEY_WOW64_64KEY, nullptr, &key, &disposition);
+  if (created != ERROR_SUCCESS) return false;
+  const DWORD enabled = 0;
+  const LONG written = RegSetValueExW(key, manifest_path.c_str(), 0, REG_DWORD,
+                                      reinterpret_cast<const BYTE*>(&enabled), sizeof(enabled));
+  RegCloseKey(key);
+  return written == ERROR_SUCCESS;
+}
+
+bool unregister_user_implicit_layer(const std::wstring& manifest_name) {
+  HKEY key = nullptr;
+  const LONG opened = RegOpenKeyExW(HKEY_CURRENT_USER, kImplicitLayersKey, 0,
+                                     KEY_QUERY_VALUE | KEY_SET_VALUE | KEY_WOW64_64KEY, &key);
+  if (opened == ERROR_FILE_NOT_FOUND) return true;
+  if (opened != ERROR_SUCCESS) return false;
+
+  const auto expected_name = lowercase(std::filesystem::path(manifest_name).filename().wstring());
+  std::vector<std::wstring> matches;
+  for (DWORD index = 0;; ++index) {
+    std::wstring value_name(32768, L'\0');
+    DWORD length = static_cast<DWORD>(value_name.size());
+    const LONG status = RegEnumValueW(key, index, value_name.data(), &length, nullptr, nullptr, nullptr, nullptr);
+    if (status == ERROR_NO_MORE_ITEMS) break;
+    if (status != ERROR_SUCCESS) {
+      RegCloseKey(key);
+      return false;
+    }
+    value_name.resize(length);
+    if (lowercase(std::filesystem::path(value_name).filename().wstring()) == expected_name) {
+      matches.emplace_back(std::move(value_name));
+    }
+  }
+
+  bool success = true;
+  for (const auto& value_name : matches) {
+    const LONG removed = RegDeleteValueW(key, value_name.c_str());
+    success = success && (removed == ERROR_SUCCESS || removed == ERROR_FILE_NOT_FOUND);
+  }
+  RegCloseKey(key);
+  return success;
+}
+
+void show_capability_cache(const std::wstring& path) {
+  const auto entries = zako::vulkan_hdr::read_capability_cache(path);
+  std::cout << "capability_cache_path=" << narrow(path) << " entry_count=" << entries.size() << '\n';
+  for (std::size_t index = 0; index < entries.size(); ++index) {
+    const auto& entry = entries[index];
+    std::cout << "cache[" << index << "].gpu_name=" << entry.device_name
+              << " vendor_id=" << entry.vendor_id << " device_id=" << entry.device_id
+              << " driver_version=" << entry.driver_version << " api_version=" << entry.api_version
+              << " luid=" << std::hex << static_cast<std::uint32_t>(entry.adapter_luid_high) << ':'
+              << entry.adapter_luid_low << std::dec << " windows_build=" << entry.windows_build
+              << " hdr10_create=" << ((entry.flags & zako::vulkan_hdr::kCapabilityHdr10Swapchain) != 0)
+              << " scrgb_create=" << ((entry.flags & zako::vulkan_hdr::kCapabilityScRgbSwapchain) != 0)
+              << " hdr_active=" << ((entry.flags & zako::vulkan_hdr::kCapabilityValidatedWhileHdrActive) != 0)
+              << " presented=" << ((entry.flags & zako::vulkan_hdr::kCapabilityPresented) != 0)
+              << " pixels_verified=" << ((entry.flags & zako::vulkan_hdr::kCapabilityPixelsVerified) != 0) << '\n';
+  }
+}
+
+std::optional<std::uint32_t> present_queue_family(const VulkanFunctions& vk, VkPhysicalDevice device, VkSurfaceKHR surface) {
+  std::uint32_t count = 0;
+  vk.get_queue_families(device, &count, nullptr);
+  std::vector<VkQueueFamilyProperties> families(count);
+  vk.get_queue_families(device, &count, families.data());
+  for (std::uint32_t i = 0; i < count; ++i) {
+    VkBool32 supported = 0;
+    if (families[i].queueCount > 0 && (families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0 &&
+        vk.get_surface_support(device, i, surface, &supported) == VK_SUCCESS && supported) return i;
+  }
+  return std::nullopt;
+}
+
+VkCompositeAlphaFlagBitsKHR choose_composite_alpha(VkFlags supported) {
+  for (VkFlags candidate : {1u, 2u, 4u, 8u}) if ((supported & candidate) != 0) return candidate;
+  return VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+}
+
+VkExtent2D choose_extent(const VkSurfaceCapabilitiesKHR& caps) {
+  if (caps.currentExtent.width != UINT32_MAX) return caps.currentExtent;
+  return {std::clamp(64u, caps.minImageExtent.width, caps.maxImageExtent.width),
+          std::clamp(64u, caps.minImageExtent.height, caps.maxImageExtent.height)};
+}
+
+VkResult try_forced_swapchain(const VulkanFunctions& vk, VkPhysicalDevice physical_device, VkSurfaceKHR surface,
+                              std::uint32_t queue_family, VkFormat format, VkColorSpaceKHR color_space) {
+  const float priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, nullptr, 0, queue_family, 1, &priority};
+  const char* extensions[] = {kSwapchainExtension};
+  VkDeviceCreateInfo device_info {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, nullptr, 0, 1, &queue_info, 0, nullptr, 1, extensions, nullptr};
+  VkDevice device = nullptr;
+  VkResult status = vk.create_device(physical_device, &device_info, nullptr, &device);
+  if (status != VK_SUCCESS) return status;
+
+  auto create_swapchain = vk.get_device_proc_addr ? reinterpret_cast<PFN_vkCreateSwapchainKHR>(vk.get_device_proc_addr(device, "vkCreateSwapchainKHR")) : nullptr;
+  auto destroy_swapchain = vk.get_device_proc_addr ? reinterpret_cast<PFN_vkDestroySwapchainKHR>(vk.get_device_proc_addr(device, "vkDestroySwapchainKHR")) : nullptr;
+  if (!create_swapchain || !destroy_swapchain || !vk.destroy_device) {
+    if (vk.destroy_device) vk.destroy_device(device, nullptr);
+    return -3;
+  }
+
+  VkSurfaceCapabilitiesKHR caps {};
+  status = vk.get_surface_capabilities(physical_device, surface, &caps);
+  if (status == VK_SUCCESS) {
+    std::uint32_t image_count = caps.minImageCount + 1;
+    if (caps.maxImageCount != 0) image_count = std::min(image_count, caps.maxImageCount);
+    VkSwapchainCreateInfoKHR info {};
+    info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    info.surface = surface;
+    info.minImageCount = image_count;
+    info.imageFormat = format;
+    info.imageColorSpace = color_space;
+    info.imageExtent = choose_extent(caps);
+    info.imageArrayLayers = 1;
+    info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    info.preTransform = caps.currentTransform;
+    info.compositeAlpha = choose_composite_alpha(caps.supportedCompositeAlpha);
+    info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+    info.clipped = 1;
+    VkSwapchainKHR swapchain = 0;
+    status = create_swapchain(device, &info, nullptr, &swapchain);
+    if (status == VK_SUCCESS) destroy_swapchain(device, swapchain, nullptr);
+  }
+  vk.destroy_device(device, nullptr);
+  return status;
+}
+
+template <typename T>
+T device_proc(const VulkanFunctions& vk, VkDevice device, const char* name) {
+  return vk.get_device_proc_addr ? reinterpret_cast<T>(vk.get_device_proc_addr(device, name)) : nullptr;
+}
+
+PresentTestResult run_present_test(const VulkanFunctions& vk, VkPhysicalDevice physical_device, VkSurfaceKHR surface,
+                                   std::uint32_t queue_family, VkFormat format, VkColorSpaceKHR color_space,
+                                   bool enable_hdr_metadata, std::uint32_t frame_count, DWORD hold_ms,
+                                   const float* clear_override) {
+  PresentTestResult result {};
+  const float priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, nullptr, 0, queue_family, 1, &priority};
+  std::vector<const char*> extensions {kSwapchainExtension};
+  if (enable_hdr_metadata) extensions.push_back("VK_EXT_hdr_metadata");
+  VkDeviceCreateInfo device_info {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, nullptr, 0, 1, &queue_info, 0, nullptr,
+                                  static_cast<std::uint32_t>(extensions.size()), extensions.data(), nullptr};
+  VkDevice device = nullptr;
+  result.swapchain_result = vk.create_device(physical_device, &device_info, nullptr, &device);
+  if (result.swapchain_result != VK_SUCCESS) return result;
+
+  const auto destroy_device = vk.destroy_device;
+  const auto get_queue = device_proc<PFN_vkGetDeviceQueue>(vk, device, "vkGetDeviceQueue");
+  const auto create_swapchain = device_proc<PFN_vkCreateSwapchainKHR>(vk, device, "vkCreateSwapchainKHR");
+  const auto destroy_swapchain = device_proc<PFN_vkDestroySwapchainKHR>(vk, device, "vkDestroySwapchainKHR");
+  const auto get_images = device_proc<PFN_vkGetSwapchainImagesKHR>(vk, device, "vkGetSwapchainImagesKHR");
+  const auto create_pool = device_proc<PFN_vkCreateCommandPool>(vk, device, "vkCreateCommandPool");
+  const auto destroy_pool = device_proc<PFN_vkDestroyCommandPool>(vk, device, "vkDestroyCommandPool");
+  const auto allocate_commands = device_proc<PFN_vkAllocateCommandBuffers>(vk, device, "vkAllocateCommandBuffers");
+  const auto begin_command = device_proc<PFN_vkBeginCommandBuffer>(vk, device, "vkBeginCommandBuffer");
+  const auto end_command = device_proc<PFN_vkEndCommandBuffer>(vk, device, "vkEndCommandBuffer");
+  const auto pipeline_barrier = device_proc<PFN_vkCmdPipelineBarrier>(vk, device, "vkCmdPipelineBarrier");
+  const auto clear_image = device_proc<PFN_vkCmdClearColorImage>(vk, device, "vkCmdClearColorImage");
+  const auto create_semaphore = device_proc<PFN_vkCreateSemaphore>(vk, device, "vkCreateSemaphore");
+  const auto destroy_semaphore = device_proc<PFN_vkDestroySemaphore>(vk, device, "vkDestroySemaphore");
+  const auto acquire_image = device_proc<PFN_vkAcquireNextImageKHR>(vk, device, "vkAcquireNextImageKHR");
+  const auto queue_submit = device_proc<PFN_vkQueueSubmit>(vk, device, "vkQueueSubmit");
+  const auto queue_present = device_proc<PFN_vkQueuePresentKHR>(vk, device, "vkQueuePresentKHR");
+  const auto queue_wait_idle = device_proc<PFN_vkQueueWaitIdle>(vk, device, "vkQueueWaitIdle");
+  const auto set_hdr_metadata = device_proc<PFN_vkSetHdrMetadataEXT>(vk, device, "vkSetHdrMetadataEXT");
+  if (!destroy_device || !get_queue || !create_swapchain || !destroy_swapchain || !get_images ||
+      !create_pool || !destroy_pool || !allocate_commands || !begin_command || !end_command ||
+      !pipeline_barrier || !clear_image || !create_semaphore || !destroy_semaphore || !acquire_image ||
+      !queue_submit || !queue_present || !queue_wait_idle) {
+    destroy_device(device, nullptr);
+    return result;
+  }
+
+  VkSurfaceCapabilitiesKHR caps {};
+  result.swapchain_result = vk.get_surface_capabilities(physical_device, surface, &caps);
+  if (result.swapchain_result != VK_SUCCESS || (caps.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
+    destroy_device(device, nullptr);
+    return result;
+  }
+
+  std::uint32_t image_count = caps.minImageCount + 1;
+  if (caps.maxImageCount != 0) image_count = std::min(image_count, caps.maxImageCount);
+  VkSwapchainCreateInfoKHR swapchain_info {};
+  swapchain_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+  swapchain_info.surface = surface;
+  swapchain_info.minImageCount = image_count;
+  swapchain_info.imageFormat = format;
+  swapchain_info.imageColorSpace = color_space;
+  swapchain_info.imageExtent = choose_extent(caps);
+  swapchain_info.imageArrayLayers = 1;
+  swapchain_info.imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  swapchain_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  swapchain_info.preTransform = caps.currentTransform;
+  swapchain_info.compositeAlpha = choose_composite_alpha(caps.supportedCompositeAlpha);
+  swapchain_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  swapchain_info.clipped = 1;
+  VkSwapchainKHR swapchain = 0;
+  result.swapchain_result = create_swapchain(device, &swapchain_info, nullptr, &swapchain);
+  if (result.swapchain_result != VK_SUCCESS) {
+    destroy_device(device, nullptr);
+    return result;
+  }
+
+  if (enable_hdr_metadata && set_hdr_metadata) {
+    VkHdrMetadataEXT metadata {};
+    metadata.sType = VK_STRUCTURE_TYPE_HDR_METADATA_EXT;
+    metadata.displayPrimaryRed = {0.708f, 0.292f};
+    metadata.displayPrimaryGreen = {0.170f, 0.797f};
+    metadata.displayPrimaryBlue = {0.131f, 0.046f};
+    metadata.whitePoint = {0.3127f, 0.3290f};
+    metadata.maxLuminance = 1000.0f;
+    metadata.minLuminance = 0.0001f;
+    metadata.maxContentLightLevel = 1000.0f;
+    metadata.maxFrameAverageLightLevel = 400.0f;
+    set_hdr_metadata(device, 1, &swapchain, &metadata);
+    result.metadata_submitted = true;
+  }
+
+  std::uint32_t actual_count = 0;
+  get_images(device, swapchain, &actual_count, nullptr);
+  std::vector<VkImage> images(actual_count);
+  get_images(device, swapchain, &actual_count, images.data());
+  VkCommandPoolCreateInfo pool_info {VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, nullptr, 0, queue_family};
+  VkCommandPool pool = 0;
+  if (create_pool(device, &pool_info, nullptr, &pool) != VK_SUCCESS) {
+    destroy_swapchain(device, swapchain, nullptr);
+    destroy_device(device, nullptr);
+    return result;
+  }
+  std::vector<VkCommandBuffer> commands(actual_count);
+  VkCommandBufferAllocateInfo allocate_info {VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr, pool, 0, actual_count};
+  if (allocate_commands(device, &allocate_info, commands.data()) != VK_SUCCESS) {
+    destroy_pool(device, pool, nullptr);
+    destroy_swapchain(device, swapchain, nullptr);
+    destroy_device(device, nullptr);
+    return result;
+  }
+
+  VkImageSubresourceRange range {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  VkClearColorValue clear {};
+  const float encoded_white = color_space == VK_COLOR_SPACE_HDR10_ST2084_EXT ? 0.751827f : 12.5f;
+  clear.float32[0] = clear_override ? clear_override[0] : encoded_white;
+  clear.float32[1] = clear_override ? clear_override[1] : encoded_white;
+  clear.float32[2] = clear_override ? clear_override[2] : encoded_white;
+  clear.float32[3] = 1.0f;
+  for (std::uint32_t index = 0; index < actual_count; ++index) {
+    VkCommandBufferBeginInfo begin {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
+                                    VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT, nullptr};
+    if (begin_command(commands[index], &begin) != VK_SUCCESS) continue;
+    VkImageMemoryBarrier to_transfer {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, nullptr, 0, VK_ACCESS_TRANSFER_WRITE_BIT,
+                                      VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                      VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, images[index], range};
+    pipeline_barrier(commands[index], VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                     0, nullptr, 0, nullptr, 1, &to_transfer);
+    clear_image(commands[index], images[index], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear, 1, &range);
+    VkImageMemoryBarrier to_present {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, nullptr, VK_ACCESS_TRANSFER_WRITE_BIT, 0,
+                                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+                                     VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, images[index], range};
+    pipeline_barrier(commands[index], VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
+                     0, nullptr, 0, nullptr, 1, &to_present);
+    end_command(commands[index]);
+  }
+
+  VkSemaphoreCreateInfo semaphore_info {VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, nullptr, 0};
+  VkSemaphore acquired = 0;
+  VkSemaphore rendered = 0;
+  if (create_semaphore(device, &semaphore_info, nullptr, &acquired) != VK_SUCCESS ||
+      create_semaphore(device, &semaphore_info, nullptr, &rendered) != VK_SUCCESS) {
+    if (acquired) destroy_semaphore(device, acquired, nullptr);
+    destroy_pool(device, pool, nullptr);
+    destroy_swapchain(device, swapchain, nullptr);
+    destroy_device(device, nullptr);
+    return result;
+  }
+
+  VkQueue queue = nullptr;
+  get_queue(device, queue_family, 0, &queue);
+  result.present_result = VK_SUCCESS;
+  for (std::uint32_t frame = 0; frame < frame_count; ++frame) {
+    std::uint32_t image_index = 0;
+    VkResult status = acquire_image(device, swapchain, UINT64_MAX, acquired, 0, &image_index);
+    if (status != VK_SUCCESS && status != 1000001003) { result.present_result = status; break; }
+    const VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    VkSubmitInfo submit {VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 1, &acquired, &wait_stage,
+                         1, &commands[image_index], 1, &rendered};
+    status = queue_submit(queue, 1, &submit, 0);
+    if (status != VK_SUCCESS) { result.present_result = status; break; }
+    VkPresentInfoKHR present {VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, nullptr, 1, &rendered,
+                              1, &swapchain, &image_index, nullptr};
+    status = queue_present(queue, &present);
+    if (status != VK_SUCCESS && status != 1000001003) { result.present_result = status; break; }
+    queue_wait_idle(queue);
+    ++result.frames_presented;
+    pump_messages_for(16);
+  }
+
+  queue_wait_idle(queue);
+  if (hold_ms > 0) {
+    std::cout << "holding_presented_swapchain_ms=" << hold_ms << '\n';
+    pump_messages_for(hold_ms);
+  }
+  destroy_semaphore(device, rendered, nullptr);
+  destroy_semaphore(device, acquired, nullptr);
+  destroy_pool(device, pool, nullptr);
+  destroy_swapchain(device, swapchain, nullptr);
+  destroy_device(device, nullptr);
+  return result;
+}
+
+std::uint32_t windows_build_number() {
+  struct VersionInfo {
+    ULONG size;
+    ULONG major;
+    ULONG minor;
+    ULONG build;
+    ULONG platform;
+    WCHAR service_pack[128];
+  } version {sizeof(VersionInfo)};
+  using RtlGetVersionFn = LONG(WINAPI*)(VersionInfo*);
+  const auto ntdll = GetModuleHandleW(L"ntdll.dll");
+  const auto rtl_get_version = ntdll ? reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdll, "RtlGetVersion")) : nullptr;
+  return rtl_get_version && rtl_get_version(&version) == 0 ? version.build : 0;
+}
+
+DeviceFingerprint device_fingerprint(const VulkanFunctions& vk, VkPhysicalDevice device) {
+  DeviceFingerprint result {};
+  if (!vk.get_physical_device_properties2) return result;
+  VkPhysicalDeviceIDProperties id {};
+  id.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+  VkPhysicalDeviceProperties2Probe properties {};
+  properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+  properties.pNext = &id;
+  vk.get_physical_device_properties2(device, &properties);
+
+  auto& entry = result.cache_entry;
+  entry.vendor_id = properties.properties.vendorID;
+  entry.device_id = properties.properties.deviceID;
+  entry.driver_version = properties.properties.driverVersion;
+  entry.api_version = properties.properties.apiVersion;
+  entry.windows_build = windows_build_number();
+  strncpy_s(entry.device_name, properties.properties.deviceName, _TRUNCATE);
+  result.luid_valid = id.deviceLUIDValid != 0;
+  if (result.luid_valid) {
+    std::memcpy(&entry.adapter_luid_low, id.deviceLUID, sizeof(entry.adapter_luid_low));
+    std::memcpy(&entry.adapter_luid_high, id.deviceLUID + sizeof(entry.adapter_luid_low), sizeof(entry.adapter_luid_high));
+  }
+  return result;
+}
+
+std::optional<VulkanFunctions> load_vulkan() {
+  VulkanFunctions vk {};
+  vk.module = LoadLibraryW(L"vulkan-1.dll");
+  if (!vk.module) return std::nullopt;
+  vk.get_instance_proc_addr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(GetProcAddress(vk.module, "vkGetInstanceProcAddr"));
+  if (!vk.get_instance_proc_addr) return std::nullopt;
+  vk.enumerate_instance_extensions = instance_proc<PFN_vkEnumerateInstanceExtensionProperties>(vk, nullptr, "vkEnumerateInstanceExtensionProperties");
+  vk.create_instance = instance_proc<PFN_vkCreateInstance>(vk, nullptr, "vkCreateInstance");
+  return vk;
+}
+
+void print_usage() {
+  std::cout << "Usage: vulkan_hdr_probe.exe [--list] [--display \\\\.\\DISPLAYn] [--gpu N] [--force-create]"
+               " [--present hdr10|scrgb] [--frames N] [--hold-ms N] [--clear R G B]"
+               " [--cache PATH] [--show-cache PATH] [--mark-pixels-verified PATH]"
+               " [--register-implicit-layer PATH] [--unregister-implicit-layer NAME]\n";
+}
+
+}  // namespace
+
+int wmain(int argc, wchar_t** argv) {
+  // Monitor bounds returned by GetMonitorInfo are physical desktop pixels.
+  // Opt out of DPI coordinate virtualization before positioning the probe
+  // window, otherwise mixed-DPI hosts can place it outside the selected VDD.
+  SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
+  std::wstring requested_display;
+  std::uint32_t requested_gpu = 0;
+  bool list_only = false;
+  bool force_create = false;
+  std::wstring cache_path;
+  std::wstring show_cache_path;
+  std::wstring mark_pixels_path;
+  std::wstring register_layer_path;
+  std::wstring unregister_layer_name;
+  std::wstring present_mode;
+  std::uint32_t present_frames = 60;
+  DWORD hold_ms = 0;
+  float clear_override[3] {};
+  bool has_clear_override = false;
+  for (int i = 1; i < argc; ++i) {
+    const std::wstring arg = argv[i];
+    if (arg == L"--list") list_only = true;
+    else if (arg == L"--force-create") force_create = true;
+    else if (arg == L"--display" && i + 1 < argc) requested_display = argv[++i];
+    else if (arg == L"--gpu" && i + 1 < argc) requested_gpu = static_cast<std::uint32_t>(std::wcstoul(argv[++i], nullptr, 10));
+    else if (arg == L"--cache" && i + 1 < argc) cache_path = argv[++i];
+    else if (arg == L"--show-cache" && i + 1 < argc) show_cache_path = argv[++i];
+    else if (arg == L"--mark-pixels-verified" && i + 1 < argc) mark_pixels_path = argv[++i];
+    else if (arg == L"--register-implicit-layer" && i + 1 < argc) register_layer_path = argv[++i];
+    else if (arg == L"--unregister-implicit-layer" && i + 1 < argc) unregister_layer_name = argv[++i];
+    else if (arg == L"--present" && i + 1 < argc) { present_mode = argv[++i]; force_create = true; }
+    else if (arg == L"--frames" && i + 1 < argc) present_frames = static_cast<std::uint32_t>(std::wcstoul(argv[++i], nullptr, 10));
+    else if (arg == L"--hold-ms" && i + 1 < argc) hold_ms = static_cast<DWORD>(std::wcstoul(argv[++i], nullptr, 10));
+    else if (arg == L"--clear" && i + 3 < argc) {
+      clear_override[0] = std::wcstof(argv[++i], nullptr);
+      clear_override[1] = std::wcstof(argv[++i], nullptr);
+      clear_override[2] = std::wcstof(argv[++i], nullptr);
+      has_clear_override = true;
+    }
+    else { print_usage(); return 2; }
+  }
+
+  if (!register_layer_path.empty()) {
+    const bool registered = register_user_implicit_layer(register_layer_path);
+    std::cout << "implicit_layer_registered=" << registered << " hive=HKCU\n";
+    return registered ? 0 : 17;
+  }
+
+  if (!unregister_layer_name.empty()) {
+    const bool removed = unregister_user_implicit_layer(unregister_layer_name);
+    std::cout << "implicit_layer_removed=" << removed << " hive=HKCU\n";
+    return removed ? 0 : 18;
+  }
+
+  if (!show_cache_path.empty()) {
+    show_capability_cache(show_cache_path);
+    return 0;
+  }
+
+  if (!mark_pixels_path.empty()) {
+    auto cache = zako::vulkan_hdr::read_capability_cache(mark_pixels_path);
+    std::size_t marked = 0;
+    for (auto& entry : cache) {
+      const auto required = zako::vulkan_hdr::kCapabilityValidatedWhileHdrActive |
+                            zako::vulkan_hdr::kCapabilityPresented;
+      if ((entry.flags & required) == required) {
+        entry.flags |= zako::vulkan_hdr::kCapabilityPixelsVerified;
+        ++marked;
+      }
+    }
+    const bool written = marked > 0 && write_capability_cache_atomic(mark_pixels_path, cache);
+    std::cout << "pixels_verified_marked=" << marked << " cache_written=" << written
+              << " path=" << narrow(mark_pixels_path) << '\n';
+    return written ? 0 : 16;
+  }
+
+  const auto available_displays = displays();
+  std::cout << "display_count=" << available_displays.size() << '\n';
+  for (std::size_t i = 0; i < available_displays.size(); ++i) {
+    const auto& display = available_displays[i];
+    std::cout << "display[" << i << "].name=" << narrow(display.gdi_name)
+              << " hdr_supported=" << display.hdr_supported
+              << " hdr_enabled=" << display.hdr_enabled
+              << " bounds=" << display.bounds.left << ',' << display.bounds.top << ','
+              << display.bounds.right << ',' << display.bounds.bottom << '\n';
+  }
+  if (list_only) return 0;
+  if (available_displays.empty()) return 3;
+
+  auto selected = available_displays.begin();
+  if (!requested_display.empty()) {
+    selected = std::find_if(available_displays.begin(), available_displays.end(), [&](const auto& entry) {
+      return _wcsicmp(entry.gdi_name.c_str(), requested_display.c_str()) == 0;
+    });
+    if (selected == available_displays.end()) {
+      std::cerr << "error=display_not_found\n";
+      return 4;
+    }
+  }
+  std::cout << "selected_display=" << narrow(selected->gdi_name) << " hdr_supported=" << selected->hdr_supported
+            << " hdr_enabled=" << selected->hdr_enabled << '\n';
+
+  HWND window = create_probe_window(*selected);
+  if (!window) {
+    std::cerr << "error=create_window native_error=" << GetLastError() << '\n';
+    return 5;
+  }
+  ShowWindow(window, SW_SHOWNOACTIVATE);
+  SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+  UpdateWindow(window);
+  pump_messages_for(50);
+  RECT actual_window {};
+  GetWindowRect(window, &actual_window);
+  MONITORINFOEXW actual_monitor {};
+  actual_monitor.cbSize = sizeof(actual_monitor);
+  GetMonitorInfoW(MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST), &actual_monitor);
+  std::cout << "window_visible=" << IsWindowVisible(window)
+            << " window_rect=" << actual_window.left << ',' << actual_window.top << ','
+            << actual_window.right << ',' << actual_window.bottom
+            << " window_monitor=" << narrow(actual_monitor.szDevice) << '\n';
+
+  auto loaded = load_vulkan();
+  if (!loaded || !loaded->enumerate_instance_extensions || !loaded->create_instance) {
+    std::cerr << "error=vulkan_loader_unavailable\n";
+    DestroyWindow(window);
+    return 6;
+  }
+  auto& vk = *loaded;
+  const auto extensions = instance_extensions(vk);
+  for (const char* required : {kSurfaceExtension, kWin32SurfaceExtension, kSwapchainColorspaceExtension}) {
+    std::cout << "instance_extension." << required << '=' << has_extension(extensions, required) << '\n';
+  }
+  if (!has_extension(extensions, kSurfaceExtension) || !has_extension(extensions, kWin32SurfaceExtension)) {
+    std::cerr << "error=required_surface_extension_missing\n";
+    DestroyWindow(window);
+    return 7;
+  }
+
+  std::vector<const char*> enabled {kSurfaceExtension, kWin32SurfaceExtension};
+  if (has_extension(extensions, kSwapchainColorspaceExtension)) enabled.push_back(kSwapchainColorspaceExtension);
+  VkApplicationInfo app {VK_STRUCTURE_TYPE_APPLICATION_INFO, nullptr, "Zako Vulkan HDR Probe", 1, "ZakoVDD", 1,
+                         (1u << 22) | (1u << 12)};
+  VkInstanceCreateInfo create_info {VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, nullptr, 0, &app, 0, nullptr,
+                                    static_cast<std::uint32_t>(enabled.size()), enabled.data()};
+  VkInstance instance = nullptr;
+  VkResult status = vk.create_instance(&create_info, nullptr, &instance);
+  if (status != VK_SUCCESS) {
+    std::cerr << "error=vkCreateInstance result=" << status << '\n';
+    DestroyWindow(window);
+    return 8;
+  }
+
+  vk.destroy_instance = instance_proc<PFN_vkDestroyInstance>(vk, instance, "vkDestroyInstance");
+  vk.enumerate_physical_devices = instance_proc<PFN_vkEnumeratePhysicalDevices>(vk, instance, "vkEnumeratePhysicalDevices");
+  vk.get_physical_device_properties2 = instance_proc<PFN_vkGetPhysicalDeviceProperties2>(vk, instance, "vkGetPhysicalDeviceProperties2");
+  vk.create_win32_surface = instance_proc<PFN_vkCreateWin32SurfaceKHR>(vk, instance, "vkCreateWin32SurfaceKHR");
+  vk.destroy_surface = instance_proc<PFN_vkDestroySurfaceKHR>(vk, instance, "vkDestroySurfaceKHR");
+  vk.get_surface_support = instance_proc<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>(vk, instance, "vkGetPhysicalDeviceSurfaceSupportKHR");
+  vk.get_surface_formats = instance_proc<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>(vk, instance, "vkGetPhysicalDeviceSurfaceFormatsKHR");
+  vk.get_surface_capabilities = instance_proc<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>(vk, instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
+  vk.get_queue_families = instance_proc<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(vk, instance, "vkGetPhysicalDeviceQueueFamilyProperties");
+  vk.enumerate_device_extensions = instance_proc<PFN_vkEnumerateDeviceExtensionProperties>(vk, instance, "vkEnumerateDeviceExtensionProperties");
+  vk.create_device = instance_proc<PFN_vkCreateDevice>(vk, instance, "vkCreateDevice");
+  vk.get_device_proc_addr = instance_proc<PFN_vkGetDeviceProcAddr>(vk, instance, "vkGetDeviceProcAddr");
+  vk.destroy_device = instance_proc<PFN_vkDestroyDevice>(vk, instance, "vkDestroyDevice");
+
+  VkWin32SurfaceCreateInfoKHR surface_info {VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, nullptr, 0,
+                                            GetModuleHandleW(nullptr), window};
+  VkSurfaceKHR surface = 0;
+  status = vk.create_win32_surface(instance, &surface_info, nullptr, &surface);
+  if (status != VK_SUCCESS) {
+    std::cerr << "error=vkCreateWin32SurfaceKHR result=" << status << '\n';
+    vk.destroy_instance(instance, nullptr);
+    DestroyWindow(window);
+    return 9;
+  }
+
+  std::uint32_t gpu_count = 0;
+  vk.enumerate_physical_devices(instance, &gpu_count, nullptr);
+  std::vector<VkPhysicalDevice> gpus(gpu_count);
+  vk.enumerate_physical_devices(instance, &gpu_count, gpus.data());
+  std::cout << "gpu_count=" << gpu_count << '\n';
+  if (requested_gpu >= gpu_count) {
+    std::cerr << "error=gpu_index_out_of_range\n";
+    vk.destroy_surface(instance, surface, nullptr);
+    vk.destroy_instance(instance, nullptr);
+    DestroyWindow(window);
+    return 10;
+  }
+
+  const auto gpu = gpus[requested_gpu];
+  const auto fingerprint = device_fingerprint(vk, gpu);
+  const auto& identity = fingerprint.cache_entry;
+  std::cout << "gpu_name=" << identity.device_name << '\n';
+  std::cout << "gpu_vendor_id=" << identity.vendor_id << " gpu_device_id=" << identity.device_id
+            << " driver_version=" << identity.driver_version << " api_version=" << identity.api_version << '\n';
+  std::cout << "gpu_luid_valid=" << fingerprint.luid_valid << " gpu_luid=" << std::hex
+            << static_cast<std::uint32_t>(identity.adapter_luid_high) << ':' << identity.adapter_luid_low << std::dec
+            << " windows_build=" << identity.windows_build << '\n';
+  const auto formats = surface_formats(vk, gpu, surface);
+  std::cout << "surface_format_count=" << formats.size() << '\n';
+  for (std::size_t i = 0; i < formats.size(); ++i) {
+    std::cout << "surface_format[" << i << "].format=" << formats[i].format
+              << " colorspace=" << formats[i].colorSpace << '\n';
+  }
+  const bool advertises_hdr10 = contains_pair(formats, VK_FORMAT_A2B10G10R10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT);
+  const bool advertises_scrgb = contains_pair(formats, VK_FORMAT_R16G16B16A16_SFLOAT, VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT);
+  std::cout << "advertises_hdr10_pair=" << advertises_hdr10 << '\n';
+  std::cout << "advertises_scrgb_pair=" << advertises_scrgb << '\n';
+
+  int exit_code = 0;
+  if (force_create) {
+    const auto device_exts = device_extensions(vk, gpu);
+    std::cout << "device_extension." << kSwapchainExtension << '=' << has_extension(device_exts, kSwapchainExtension) << '\n';
+    const auto queue_family = present_queue_family(vk, gpu, surface);
+    if (!has_extension(device_exts, kSwapchainExtension) || !queue_family) {
+      std::cerr << "error=swapchain_or_present_queue_unavailable\n";
+      exit_code = 11;
+    } else {
+      const VkResult hdr10 = try_forced_swapchain(vk, gpu, surface, *queue_family,
+                                                  VK_FORMAT_A2B10G10R10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT);
+      const VkResult scrgb = try_forced_swapchain(vk, gpu, surface, *queue_family,
+                                                  VK_FORMAT_R16G16B16A16_SFLOAT, VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT);
+      PresentTestResult present {};
+      bool ran_present = false;
+      if (!present_mode.empty()) {
+        const bool use_hdr10 = _wcsicmp(present_mode.c_str(), L"hdr10") == 0;
+        const bool use_scrgb = _wcsicmp(present_mode.c_str(), L"scrgb") == 0;
+        if (!use_hdr10 && !use_scrgb) {
+          std::cerr << "error=invalid_present_mode\n";
+          exit_code = 14;
+        } else {
+          const auto device_exts_for_present = device_extensions(vk, gpu);
+          const bool metadata_available = has_extension(device_exts_for_present, "VK_EXT_hdr_metadata");
+          present = run_present_test(vk, gpu, surface, *queue_family,
+                                     use_hdr10 ? VK_FORMAT_A2B10G10R10_UNORM_PACK32 : VK_FORMAT_R16G16B16A16_SFLOAT,
+                                     use_hdr10 ? VK_COLOR_SPACE_HDR10_ST2084_EXT : VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT,
+                                     use_hdr10 && metadata_available, present_frames, hold_ms,
+                                     has_clear_override ? clear_override : nullptr);
+          ran_present = true;
+          std::cout << "present_mode=" << (use_hdr10 ? "hdr10" : "scrgb")
+                    << " swapchain_result=" << present.swapchain_result
+                    << " present_result=" << present.present_result
+                    << " frames_presented=" << present.frames_presented
+                    << " hdr_metadata_submitted=" << present.metadata_submitted << '\n';
+          if (present.swapchain_result != VK_SUCCESS || present.present_result != VK_SUCCESS || present.frames_presented == 0) exit_code = 15;
+        }
+      }
+      std::cout << "forced_hdr10_swapchain_result=" << hdr10 << " success=" << (hdr10 == VK_SUCCESS) << '\n';
+      std::cout << "forced_scrgb_swapchain_result=" << scrgb << " success=" << (scrgb == VK_SUCCESS) << '\n';
+      std::cout << "capability_cache_eligible="
+                << (selected->hdr_enabled && (hdr10 == VK_SUCCESS || scrgb == VK_SUCCESS)) << '\n';
+      if (!selected->hdr_enabled) {
+        std::cout << "warning=forced_swapchain_was_not_presented_on_an_active_hdr_display\n";
+      }
+      if (!cache_path.empty()) {
+        auto entry = fingerprint.cache_entry;
+        if (hdr10 == VK_SUCCESS) entry.flags |= zako::vulkan_hdr::kCapabilityHdr10Swapchain;
+        if (scrgb == VK_SUCCESS) entry.flags |= zako::vulkan_hdr::kCapabilityScRgbSwapchain;
+        if (selected->hdr_enabled) entry.flags |= zako::vulkan_hdr::kCapabilityValidatedWhileHdrActive;
+        if (ran_present && present.present_result == VK_SUCCESS && present.frames_presented > 0) {
+          entry.flags |= zako::vulkan_hdr::kCapabilityPresented;
+        }
+        auto cache = zako::vulkan_hdr::read_capability_cache(cache_path);
+        zako::vulkan_hdr::upsert_capability(cache, entry);
+        const bool written = write_capability_cache_atomic(cache_path, cache);
+        std::cout << "capability_cache_written=" << written << " path=" << narrow(cache_path) << '\n';
+        if (!written && exit_code == 0) exit_code = 13;
+      }
+      if (hdr10 != VK_SUCCESS && scrgb != VK_SUCCESS) exit_code = 12;
+    }
+  }
+
+  vk.destroy_surface(instance, surface, nullptr);
+  vk.destroy_instance(instance, nullptr);
+  FreeLibrary(vk.module);
+  DestroyWindow(window);
+  return exit_code;
+}

--- a/tools/vulkan_hdr_probe/vulkan_minimal.h
+++ b/tools/vulkan_hdr_probe/vulkan_minimal.h
@@ -1,0 +1,366 @@
+#pragma once
+
+// Minimal Vulkan 1.x ABI declarations used by the standalone diagnostic probe.
+// The probe loads vulkan-1.dll dynamically so end users do not need the Vulkan
+// SDK. The production layer must use pinned Khronos Vulkan-Headers instead.
+
+#include <cstdint>
+#include <cstddef>
+
+#define VKAPI_PTR __stdcall
+
+using VkFlags = std::uint32_t;
+using VkBool32 = std::uint32_t;
+using VkDeviceSize = std::uint64_t;
+using VkResult = std::int32_t;
+using VkFormat = std::int32_t;
+using VkColorSpaceKHR = std::int32_t;
+using VkPresentModeKHR = std::int32_t;
+using VkStructureType = std::int32_t;
+using VkImageUsageFlags = VkFlags;
+using VkSurfaceTransformFlagBitsKHR = VkFlags;
+using VkCompositeAlphaFlagBitsKHR = VkFlags;
+using VkSharingMode = std::int32_t;
+using VkImageLayout = std::int32_t;
+using VkCommandBufferLevel = std::int32_t;
+using VkPipelineStageFlags = VkFlags;
+using VkAccessFlags = VkFlags;
+using VkInstance = struct VkInstance_T*;
+using VkPhysicalDevice = struct VkPhysicalDevice_T*;
+using VkDevice = struct VkDevice_T*;
+using VkQueue = struct VkQueue_T*;
+using VkSurfaceKHR = std::uint64_t;
+using VkSwapchainKHR = std::uint64_t;
+using VkImage = std::uint64_t;
+using VkCommandPool = std::uint64_t;
+using VkCommandBuffer = struct VkCommandBuffer_T*;
+using VkSemaphore = std::uint64_t;
+using VkFence = std::uint64_t;
+
+constexpr VkResult VK_SUCCESS = 0;
+constexpr VkResult VK_INCOMPLETE = 5;
+constexpr VkStructureType VK_STRUCTURE_TYPE_APPLICATION_INFO = 0;
+constexpr VkStructureType VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1;
+constexpr VkStructureType VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = 2;
+constexpr VkStructureType VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO = 3;
+constexpr VkStructureType VK_STRUCTURE_TYPE_SUBMIT_INFO = 4;
+constexpr VkStructureType VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO = 9;
+constexpr VkStructureType VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO = 39;
+constexpr VkStructureType VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO = 40;
+constexpr VkStructureType VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO = 42;
+constexpr VkStructureType VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = 45;
+constexpr VkStructureType VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR = 1000001000;
+constexpr VkStructureType VK_STRUCTURE_TYPE_PRESENT_INFO_KHR = 1000001001;
+constexpr VkStructureType VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR = 1000009000;
+constexpr VkStructureType VK_STRUCTURE_TYPE_HDR_METADATA_EXT = 1000105000;
+constexpr VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 = 1000059001;
+constexpr VkStructureType VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES = 1000071004;
+constexpr VkFormat VK_FORMAT_A2B10G10R10_UNORM_PACK32 = 64;
+constexpr VkFormat VK_FORMAT_R16G16B16A16_SFLOAT = 97;
+constexpr VkColorSpaceKHR VK_COLOR_SPACE_SRGB_NONLINEAR_KHR = 0;
+constexpr VkColorSpaceKHR VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT = 1000104002;
+constexpr VkColorSpaceKHR VK_COLOR_SPACE_HDR10_ST2084_EXT = 1000104008;
+constexpr VkPresentModeKHR VK_PRESENT_MODE_FIFO_KHR = 2;
+constexpr VkImageUsageFlags VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = 0x10;
+constexpr VkImageUsageFlags VK_IMAGE_USAGE_TRANSFER_DST_BIT = 0x2;
+constexpr VkSharingMode VK_SHARING_MODE_EXCLUSIVE = 0;
+constexpr VkFlags VK_QUEUE_GRAPHICS_BIT = 0x1;
+constexpr VkCompositeAlphaFlagBitsKHR VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = 0x1;
+constexpr VkImageLayout VK_IMAGE_LAYOUT_UNDEFINED = 0;
+constexpr VkImageLayout VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = 7;
+constexpr VkImageLayout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR = 1000001002;
+constexpr VkPipelineStageFlags VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = 0x1;
+constexpr VkPipelineStageFlags VK_PIPELINE_STAGE_TRANSFER_BIT = 0x1000;
+constexpr VkPipelineStageFlags VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = 0x2000;
+constexpr VkAccessFlags VK_ACCESS_TRANSFER_WRITE_BIT = 0x1000;
+constexpr VkFlags VK_IMAGE_ASPECT_COLOR_BIT = 0x1;
+constexpr VkFlags VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = 0x4;
+constexpr std::uint32_t VK_QUEUE_FAMILY_IGNORED = 0xffffffffu;
+
+struct VkExtent2D {
+  std::uint32_t width;
+  std::uint32_t height;
+};
+
+struct VkExtent3D {
+  std::uint32_t width;
+  std::uint32_t height;
+  std::uint32_t depth;
+};
+
+struct VkApplicationInfo {
+  VkStructureType sType;
+  const void* pNext;
+  const char* pApplicationName;
+  std::uint32_t applicationVersion;
+  const char* pEngineName;
+  std::uint32_t engineVersion;
+  std::uint32_t apiVersion;
+};
+
+struct VkInstanceCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  const VkApplicationInfo* pApplicationInfo;
+  std::uint32_t enabledLayerCount;
+  const char* const* ppEnabledLayerNames;
+  std::uint32_t enabledExtensionCount;
+  const char* const* ppEnabledExtensionNames;
+};
+
+struct VkDeviceQueueCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  std::uint32_t queueFamilyIndex;
+  std::uint32_t queueCount;
+  const float* pQueuePriorities;
+};
+
+struct VkDeviceCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  std::uint32_t queueCreateInfoCount;
+  const VkDeviceQueueCreateInfo* pQueueCreateInfos;
+  std::uint32_t enabledLayerCount;
+  const char* const* ppEnabledLayerNames;
+  std::uint32_t enabledExtensionCount;
+  const char* const* ppEnabledExtensionNames;
+  const void* pEnabledFeatures;
+};
+
+struct VkWin32SurfaceCreateInfoKHR {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  void* hinstance;
+  void* hwnd;
+};
+
+struct VkSurfaceFormatKHR {
+  VkFormat format;
+  VkColorSpaceKHR colorSpace;
+};
+
+struct VkSurfaceFormat2KHR {
+  VkStructureType sType;
+  void* pNext;
+  VkSurfaceFormatKHR surfaceFormat;
+};
+
+struct VkPhysicalDeviceSurfaceInfo2KHR {
+  VkStructureType sType;
+  const void* pNext;
+  VkSurfaceKHR surface;
+};
+
+struct VkSurfaceCapabilitiesKHR {
+  std::uint32_t minImageCount;
+  std::uint32_t maxImageCount;
+  VkExtent2D currentExtent;
+  VkExtent2D minImageExtent;
+  VkExtent2D maxImageExtent;
+  std::uint32_t maxImageArrayLayers;
+  VkFlags supportedTransforms;
+  VkSurfaceTransformFlagBitsKHR currentTransform;
+  VkFlags supportedCompositeAlpha;
+  VkImageUsageFlags supportedUsageFlags;
+};
+
+struct VkSwapchainCreateInfoKHR {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  VkSurfaceKHR surface;
+  std::uint32_t minImageCount;
+  VkFormat imageFormat;
+  VkColorSpaceKHR imageColorSpace;
+  VkExtent2D imageExtent;
+  std::uint32_t imageArrayLayers;
+  VkImageUsageFlags imageUsage;
+  VkSharingMode imageSharingMode;
+  std::uint32_t queueFamilyIndexCount;
+  const std::uint32_t* pQueueFamilyIndices;
+  VkSurfaceTransformFlagBitsKHR preTransform;
+  VkCompositeAlphaFlagBitsKHR compositeAlpha;
+  VkPresentModeKHR presentMode;
+  VkBool32 clipped;
+  VkSwapchainKHR oldSwapchain;
+};
+
+struct VkSemaphoreCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+};
+
+struct VkCommandPoolCreateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  std::uint32_t queueFamilyIndex;
+};
+
+struct VkCommandBufferAllocateInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkCommandPool commandPool;
+  VkCommandBufferLevel level;
+  std::uint32_t commandBufferCount;
+};
+
+struct VkCommandBufferBeginInfo {
+  VkStructureType sType;
+  const void* pNext;
+  VkFlags flags;
+  const void* pInheritanceInfo;
+};
+
+struct VkImageSubresourceRange {
+  VkFlags aspectMask;
+  std::uint32_t baseMipLevel;
+  std::uint32_t levelCount;
+  std::uint32_t baseArrayLayer;
+  std::uint32_t layerCount;
+};
+
+struct VkImageMemoryBarrier {
+  VkStructureType sType;
+  const void* pNext;
+  VkAccessFlags srcAccessMask;
+  VkAccessFlags dstAccessMask;
+  VkImageLayout oldLayout;
+  VkImageLayout newLayout;
+  std::uint32_t srcQueueFamilyIndex;
+  std::uint32_t dstQueueFamilyIndex;
+  VkImage image;
+  VkImageSubresourceRange subresourceRange;
+};
+
+union VkClearColorValue {
+  float float32[4];
+  std::int32_t int32[4];
+  std::uint32_t uint32[4];
+};
+
+struct VkSubmitInfo {
+  VkStructureType sType;
+  const void* pNext;
+  std::uint32_t waitSemaphoreCount;
+  const VkSemaphore* pWaitSemaphores;
+  const VkPipelineStageFlags* pWaitDstStageMask;
+  std::uint32_t commandBufferCount;
+  const VkCommandBuffer* pCommandBuffers;
+  std::uint32_t signalSemaphoreCount;
+  const VkSemaphore* pSignalSemaphores;
+};
+
+struct VkPresentInfoKHR {
+  VkStructureType sType;
+  const void* pNext;
+  std::uint32_t waitSemaphoreCount;
+  const VkSemaphore* pWaitSemaphores;
+  std::uint32_t swapchainCount;
+  const VkSwapchainKHR* pSwapchains;
+  const std::uint32_t* pImageIndices;
+  VkResult* pResults;
+};
+
+struct VkXYColorEXT { float x; float y; };
+
+struct VkHdrMetadataEXT {
+  VkStructureType sType;
+  const void* pNext;
+  VkXYColorEXT displayPrimaryRed;
+  VkXYColorEXT displayPrimaryGreen;
+  VkXYColorEXT displayPrimaryBlue;
+  VkXYColorEXT whitePoint;
+  float maxLuminance;
+  float minLuminance;
+  float maxContentLightLevel;
+  float maxFrameAverageLightLevel;
+};
+
+struct VkQueueFamilyProperties {
+  VkFlags queueFlags;
+  std::uint32_t queueCount;
+  std::uint32_t timestampValidBits;
+  VkExtent3D minImageTransferGranularity;
+};
+
+struct VkExtensionProperties {
+  char extensionName[256];
+  std::uint32_t specVersion;
+};
+
+// The properties prefix is stable Vulkan ABI. The opaque tail is deliberately
+// oversized because the probe only reads the prefix while the loader writes
+// the full VkPhysicalDeviceLimits/SparseProperties payload.
+struct VkPhysicalDevicePropertiesPrefix {
+  std::uint32_t apiVersion;
+  std::uint32_t driverVersion;
+  std::uint32_t vendorID;
+  std::uint32_t deviceID;
+  std::int32_t deviceType;
+  char deviceName[256];
+  std::uint8_t pipelineCacheUUID[16];
+  std::byte opaqueTail[1024];
+};
+
+struct VkPhysicalDeviceProperties2Probe {
+  VkStructureType sType;
+  const void* pNext;
+  VkPhysicalDevicePropertiesPrefix properties;
+};
+
+struct VkPhysicalDeviceIDProperties {
+  VkStructureType sType;
+  void* pNext;
+  std::uint8_t deviceUUID[16];
+  std::uint8_t driverUUID[16];
+  std::uint8_t deviceLUID[8];
+  std::uint32_t deviceNodeMask;
+  VkBool32 deviceLUIDValid;
+};
+
+using PFN_vkVoidFunction = void(VKAPI_PTR*)();
+using PFN_vkGetInstanceProcAddr = PFN_vkVoidFunction(VKAPI_PTR*)(VkInstance, const char*);
+using PFN_vkGetDeviceProcAddr = PFN_vkVoidFunction(VKAPI_PTR*)(VkDevice, const char*);
+using PFN_vkEnumerateInstanceExtensionProperties = VkResult(VKAPI_PTR*)(const char*, std::uint32_t*, VkExtensionProperties*);
+using PFN_vkCreateInstance = VkResult(VKAPI_PTR*)(const VkInstanceCreateInfo*, const void*, VkInstance*);
+using PFN_vkDestroyInstance = void(VKAPI_PTR*)(VkInstance, const void*);
+using PFN_vkEnumeratePhysicalDevices = VkResult(VKAPI_PTR*)(VkInstance, std::uint32_t*, VkPhysicalDevice*);
+using PFN_vkGetPhysicalDeviceProperties2 = void(VKAPI_PTR*)(VkPhysicalDevice, VkPhysicalDeviceProperties2Probe*);
+using PFN_vkCreateWin32SurfaceKHR = VkResult(VKAPI_PTR*)(VkInstance, const VkWin32SurfaceCreateInfoKHR*, const void*, VkSurfaceKHR*);
+using PFN_vkDestroySurfaceKHR = void(VKAPI_PTR*)(VkInstance, VkSurfaceKHR, const void*);
+using PFN_vkGetPhysicalDeviceSurfaceSupportKHR = VkResult(VKAPI_PTR*)(VkPhysicalDevice, std::uint32_t, VkSurfaceKHR, VkBool32*);
+using PFN_vkGetPhysicalDeviceSurfaceFormatsKHR = VkResult(VKAPI_PTR*)(VkPhysicalDevice, VkSurfaceKHR, std::uint32_t*, VkSurfaceFormatKHR*);
+using PFN_vkGetPhysicalDeviceSurfaceFormats2KHR = VkResult(VKAPI_PTR*)(VkPhysicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR*, std::uint32_t*, VkSurfaceFormat2KHR*);
+using PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR = VkResult(VKAPI_PTR*)(VkPhysicalDevice, VkSurfaceKHR, VkSurfaceCapabilitiesKHR*);
+using PFN_vkGetPhysicalDeviceQueueFamilyProperties = void(VKAPI_PTR*)(VkPhysicalDevice, std::uint32_t*, VkQueueFamilyProperties*);
+using PFN_vkEnumerateDeviceExtensionProperties = VkResult(VKAPI_PTR*)(VkPhysicalDevice, const char*, std::uint32_t*, VkExtensionProperties*);
+using PFN_vkCreateDevice = VkResult(VKAPI_PTR*)(VkPhysicalDevice, const VkDeviceCreateInfo*, const void*, VkDevice*);
+using PFN_vkDestroyDevice = void(VKAPI_PTR*)(VkDevice, const void*);
+using PFN_vkCreateSwapchainKHR = VkResult(VKAPI_PTR*)(VkDevice, const VkSwapchainCreateInfoKHR*, const void*, VkSwapchainKHR*);
+using PFN_vkDestroySwapchainKHR = void(VKAPI_PTR*)(VkDevice, VkSwapchainKHR, const void*);
+using PFN_vkGetDeviceQueue = void(VKAPI_PTR*)(VkDevice, std::uint32_t, std::uint32_t, VkQueue*);
+using PFN_vkGetSwapchainImagesKHR = VkResult(VKAPI_PTR*)(VkDevice, VkSwapchainKHR, std::uint32_t*, VkImage*);
+using PFN_vkCreateCommandPool = VkResult(VKAPI_PTR*)(VkDevice, const VkCommandPoolCreateInfo*, const void*, VkCommandPool*);
+using PFN_vkDestroyCommandPool = void(VKAPI_PTR*)(VkDevice, VkCommandPool, const void*);
+using PFN_vkAllocateCommandBuffers = VkResult(VKAPI_PTR*)(VkDevice, const VkCommandBufferAllocateInfo*, VkCommandBuffer*);
+using PFN_vkBeginCommandBuffer = VkResult(VKAPI_PTR*)(VkCommandBuffer, const VkCommandBufferBeginInfo*);
+using PFN_vkEndCommandBuffer = VkResult(VKAPI_PTR*)(VkCommandBuffer);
+using PFN_vkCmdPipelineBarrier = void(VKAPI_PTR*)(VkCommandBuffer, VkPipelineStageFlags, VkPipelineStageFlags, VkFlags,
+                                                  std::uint32_t, const void*, std::uint32_t, const void*,
+                                                  std::uint32_t, const VkImageMemoryBarrier*);
+using PFN_vkCmdClearColorImage = void(VKAPI_PTR*)(VkCommandBuffer, VkImage, VkImageLayout, const VkClearColorValue*,
+                                                  std::uint32_t, const VkImageSubresourceRange*);
+using PFN_vkCreateSemaphore = VkResult(VKAPI_PTR*)(VkDevice, const VkSemaphoreCreateInfo*, const void*, VkSemaphore*);
+using PFN_vkDestroySemaphore = void(VKAPI_PTR*)(VkDevice, VkSemaphore, const void*);
+using PFN_vkAcquireNextImageKHR = VkResult(VKAPI_PTR*)(VkDevice, VkSwapchainKHR, std::uint64_t, VkSemaphore, VkFence, std::uint32_t*);
+using PFN_vkQueueSubmit = VkResult(VKAPI_PTR*)(VkQueue, std::uint32_t, const VkSubmitInfo*, VkFence);
+using PFN_vkQueuePresentKHR = VkResult(VKAPI_PTR*)(VkQueue, const VkPresentInfoKHR*);
+using PFN_vkQueueWaitIdle = VkResult(VKAPI_PTR*)(VkQueue);
+using PFN_vkSetHdrMetadataEXT = void(VKAPI_PTR*)(VkDevice, std::uint32_t, const VkSwapchainKHR*, const VkHdrMetadataEXT*);


### PR DESCRIPTION
## 改了啥呀

- 新增 Vulkan HDR WSI compatibility layer，只在探针确认虚拟显示器 HDR active 后补齐缺失的 HDR10/scRGB surface formats 与 colorspaces。
- 新增 capability cache、Vulkan HDR probe、policy 单测和注册/清理工具，桥接是否生效有完整可观测状态。
- 扩展 VDD capture test，验证 HDR 桌面帧、原始/Layer format 枚举、swapchain 创建与 present，不再只看“游戏里出现 HDR 开关”。
- 更新构建与 CI，将桥接 DLL、manifest、probe 一起纳入发布产物。

## 为啥要改

部分原生 Vulkan HDR 游戏会先查询 ICD 的 surface formats/colorspaces。虚拟显示器即使 Windows HDR 已开启，只要 ICD 不返回 HDR colorspace，游戏仍会隐藏 HDR 选项。

这层桥接只修正已由系统与探针证明的能力缺口，不伪造 HDR 状态。杂鱼 bug 想靠“swapchain 创建成功”蒙混过关也不行啦，必须从系统 HDR 状态一直闭环到 present。

## 验证

- `vulkan_hdr_policy_test=PASS`
- VDD Release 构建通过（仅保留既有 INF 警告）
- 本机虚拟显示器：Windows HDR supported/enabled
- scRGB 桌面捕获连续获得有效帧
- ICD 原始 formats 5 个，Layer formats 7 个
- HDR10 与 scRGB swapchain 创建及 present 成功
- 像素路径已验证
- `git diff --check` 通过

尚未使用《夺宝奇兵：古老之圈》做游戏内最终验证；当前证据覆盖系统、ICD/Layer、swapchain 与像素链路。