### PR TITLE
fix(release): package driver from artifact root

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -271,11 +271,11 @@ jobs:
         run: |
           cd driver-x64
           zip -j ../zakovdd.zip \
-            ZakoVDD/ZakoVDD.dll \
-            ZakoVDD/ZakoVDD.inf \
-            ZakoVDD/zakovdd.cat \
-            ZakoVDD/vdd_settings.xml \
-            ZakoVDD.cer \
+            x64/Release/ZakoVDD/ZakoVDD.dll \
+            x64/Release/ZakoVDD/ZakoVDD.inf \
+            x64/Release/ZakoVDD/zakovdd.cat \
+            x64/Release/ZakoVDD/vdd_settings.xml \
+            x64/Release/ZakoVDD.cer \
             tools/vulkan_hdr_bridge/build/zako_vulkan_hdr_bridge.dll \
             tools/vulkan_hdr_bridge/build/VkLayer_zako_virtual_hdr.json \
             tools/vulkan_hdr_probe/build/vulkan_hdr_probe.exe


### PR DESCRIPTION
## 改了啥呀

- 修正 release job 在下载多根目录 artifact 后使用的驱动文件路径。
- 保持 `zip -j` 的扁平发布结构，最终 ZIP 仍包含原有 5 个驱动文件与 3 个 Vulkan HDR 工件。

## 为啥要改

加入 `tools/...` 工件后，upload-artifact 的公共根目录变成仓库根目录；杂鱼打包脚本还按旧的 `ZakoVDD/...` 路径找文件，导致 `v0.16.4` release job 只打进 HDR 文件后校验失败。

## 验证

- 下载失败 run `29190300890` 的真实 artifact
- 验证修正后的 8 个输入路径全部存在：`release_paths_verified=8`
- `git diff --check` 通过