### PR TITLE
fix(vdd): gate frame channel on committed display state

### DIFF
--- a/ZakoVDD/Callbacks/IddCallbacks.cpp
+++ b/ZakoVDD/Callbacks/IddCallbacks.cpp
@@ -351,7 +351,11 @@ _Use_decl_annotations_
 	auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(MonitorObject);
 	if (pContext && pContext->pContext)
 	{
-		pContext->pContext->UpdateMonitorHdrMetadata(MonitorObject, true, maxNits, minNits, maxFALL);
+		// This callback supplies default HDR10 mastering metadata for any
+		// HDR-capable monitor. It is not an indication that the active path is
+		// currently in HDR mode; CommitModes2 and per-frame surface color space
+		// are authoritative for that state.
+		pContext->pContext->UpdateMonitorHdrLuminanceMetadata(MonitorObject, maxNits, minNits, maxFALL);
 	}
 
 	VDD_LOG_DEBUG("Default HDR metadata set successfully.");

--- a/ZakoVDD/Device/IndirectDeviceContext.h
+++ b/ZakoVDD/Device/IndirectDeviceContext.h
@@ -28,7 +28,7 @@ namespace Microsoft
 			void UnassignSwapChain(IDDCX_MONITOR Monitor);
 			void CommitModes(const IDARG_IN_COMMITMODES *pInArgs);
 			void CommitModes2(const IDARG_IN_COMMITMODES2 *pInArgs);
-			void UpdateMonitorHdrMetadata(IDDCX_MONITOR Monitor, bool isHdr, float maxNits, float minNits, float maxFALL);
+			void UpdateMonitorHdrLuminanceMetadata(IDDCX_MONITOR Monitor, float maxNits, float minNits, float maxFALL);
 			NTSTATUS OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
 			                          HANDLE targetProcess,
 			                          VDD_FRAME_CHANNEL_OPEN_RESPONSE& response);
@@ -49,6 +49,9 @@ namespace Microsoft
 			std::map<unsigned int, GUID> m_MonitorGuids;
 
 			std::map<IDDCX_MONITOR, DISPLAYCONFIG_VIDEO_SIGNAL_INFO> m_CommittedTargetModes;
+			// Presence in this map means CommitModes2 supplied an authoritative
+			// target color space. The bool is true for HDR10 and false for SDR/WCG.
+			std::map<IDDCX_MONITOR, bool> m_CommittedTargetHdrStates;
 			std::map<IDDCX_MONITOR, std::unique_ptr<SwapChainProcessor>> m_ProcessingThreads;
 			std::map<IDDCX_MONITOR, HANDLE> m_MouseEvents;
 

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -183,14 +183,13 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		{
 			lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
 			MonitorHdrSettings hdrSettings;
-			hdrSettings.isHdr = false;
 			hdrSettings.maxNits = maxNits;
 			hdrSettings.minNits = minNits;
 			hdrSettings.maxFALL = maxFALL;
 			s_MonitorHdrSettingsMap[newMonitor] = hdrSettings;
 
-			VDD_LOG_DEBUG_STREAM("Stored HDR settings for monitor " << (index + 1)
-			                     << " - IsHdr: false, MaxNits: " << maxNits
+			VDD_LOG_DEBUG_STREAM("Stored HDR luminance settings for monitor " << (index + 1)
+			                     << " - MaxNits: " << maxNits
 			                     << ", MinNits: " << minNits
 			                     << ", MaxFALL: " << maxFALL);
 		}
@@ -243,6 +242,7 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 		}
 
 		m_CommittedTargetModes.erase(hMonitor);
+		m_CommittedTargetHdrStates.erase(hMonitor);
 
 		{
 			auto guidIt = m_MonitorGuids.find(index);

--- a/ZakoVDD/Device/MonitorState.h
+++ b/ZakoVDD/Device/MonitorState.h
@@ -35,7 +35,6 @@ struct GuidComparator
 
 struct MonitorHdrSettings
 {
-	bool isHdr;
 	float maxNits;
 	float minNits;
 	float maxFALL;

--- a/ZakoVDD/Device/SwapChainLifecycle.cpp
+++ b/ZakoVDD/Device/SwapChainLifecycle.cpp
@@ -52,17 +52,20 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 		auto modeIt = m_CommittedTargetModes.find(Monitor);
 		if (modeIt != m_CommittedTargetModes.end())
 		{
-			procIt->second->PublishModeMetadata(modeIt->second);
+			auto hdrIt = m_CommittedTargetHdrStates.find(Monitor);
+			const bool hasExpectedHdrState = hdrIt != m_CommittedTargetHdrStates.end();
+			procIt->second->PublishModeMetadata(modeIt->second,
+			                                    hasExpectedHdrState,
+			                                    hasExpectedHdrState && hdrIt->second);
 		}
 
 		lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
 		auto hdrIt = s_MonitorHdrSettingsMap.find(Monitor);
 		if (hdrIt != s_MonitorHdrSettingsMap.end())
 		{
-			procIt->second->UpdateHdrMetadata(hdrIt->second.isHdr,
-			                                hdrIt->second.maxNits,
-			                                hdrIt->second.minNits,
-			                                hdrIt->second.maxFALL);
+			procIt->second->UpdateHdrLuminanceMetadata(hdrIt->second.maxNits,
+			                                           hdrIt->second.minNits,
+			                                           hdrIt->second.maxFALL);
 		}
 	}
 
@@ -135,16 +138,18 @@ void IndirectDeviceContext::CommitModes(const IDARG_IN_COMMITMODES *pInArgs)
 		if ((path.Flags & IDDCX_PATH_FLAGS_ACTIVE) != 0)
 		{
 			m_CommittedTargetModes[path.MonitorObject] = path.TargetVideoSignalInfo;
+			m_CommittedTargetHdrStates.erase(path.MonitorObject);
 
 			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
 			if (procIt != m_ProcessingThreads.end() && procIt->second)
 			{
-				procIt->second->PublishModeMetadata(path.TargetVideoSignalInfo);
+				procIt->second->PublishModeMetadata(path.TargetVideoSignalInfo, false, false);
 			}
 		}
 		else
 		{
 			m_CommittedTargetModes.erase(path.MonitorObject);
+			m_CommittedTargetHdrStates.erase(path.MonitorObject);
 
 			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
 			if (procIt != m_ProcessingThreads.end() && procIt->second)
@@ -174,16 +179,31 @@ void IndirectDeviceContext::CommitModes2(const IDARG_IN_COMMITMODES2 *pInArgs)
 		if ((path.Flags & IDDCX_PATH_FLAGS_ACTIVE) != 0)
 		{
 			m_CommittedTargetModes[path.MonitorObject] = path.TargetVideoSignalInfo;
+			const bool hasExpectedHdrState =
+				path.WireFormatInfo.ColorSpace != IDDCX_COLOR_SPACE_UNINITIALIZED;
+			const bool expectedIsHdr =
+				path.WireFormatInfo.ColorSpace == IDDCX_COLOR_SPACE_G2084_P2020;
+			if (hasExpectedHdrState)
+			{
+				m_CommittedTargetHdrStates[path.MonitorObject] = expectedIsHdr;
+			}
+			else
+			{
+				m_CommittedTargetHdrStates.erase(path.MonitorObject);
+			}
 
 			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
 			if (procIt != m_ProcessingThreads.end() && procIt->second)
 			{
-				procIt->second->PublishModeMetadata(path.TargetVideoSignalInfo);
+				procIt->second->PublishModeMetadata(path.TargetVideoSignalInfo,
+				                                    hasExpectedHdrState,
+				                                    expectedIsHdr);
 			}
 		}
 		else
 		{
 			m_CommittedTargetModes.erase(path.MonitorObject);
+			m_CommittedTargetHdrStates.erase(path.MonitorObject);
 
 			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
 			if (procIt != m_ProcessingThreads.end() && procIt->second)
@@ -194,14 +214,13 @@ void IndirectDeviceContext::CommitModes2(const IDARG_IN_COMMITMODES2 *pInArgs)
 	}
 }
 
-void IndirectDeviceContext::UpdateMonitorHdrMetadata(IDDCX_MONITOR Monitor, bool isHdr, float maxNits, float minNits, float maxFALL)
+void IndirectDeviceContext::UpdateMonitorHdrLuminanceMetadata(IDDCX_MONITOR Monitor, float maxNits, float minNits, float maxFALL)
 {
 	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
 
 	{
 		lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
 		auto &hdrSettings = s_MonitorHdrSettingsMap[Monitor];
-		hdrSettings.isHdr = isHdr;
 		hdrSettings.maxNits = maxNits;
 		hdrSettings.minNits = minNits;
 		hdrSettings.maxFALL = maxFALL;
@@ -210,7 +229,7 @@ void IndirectDeviceContext::UpdateMonitorHdrMetadata(IDDCX_MONITOR Monitor, bool
 	auto procIt = m_ProcessingThreads.find(Monitor);
 	if (procIt != m_ProcessingThreads.end() && procIt->second)
 	{
-		procIt->second->UpdateHdrMetadata(isHdr, maxNits, minNits, maxFALL);
+		procIt->second->UpdateHdrLuminanceMetadata(maxNits, minNits, maxFALL);
 	}
 }
 

--- a/ZakoVDD/Device/SwapChainLifecycle.cpp
+++ b/ZakoVDD/Device/SwapChainLifecycle.cpp
@@ -145,6 +145,12 @@ void IndirectDeviceContext::CommitModes(const IDARG_IN_COMMITMODES *pInArgs)
 		else
 		{
 			m_CommittedTargetModes.erase(path.MonitorObject);
+
+			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
+			if (procIt != m_ProcessingThreads.end() && procIt->second)
+			{
+				procIt->second->ClearExpectedMode();
+			}
 		}
 	}
 }
@@ -178,6 +184,12 @@ void IndirectDeviceContext::CommitModes2(const IDARG_IN_COMMITMODES2 *pInArgs)
 		else
 		{
 			m_CommittedTargetModes.erase(path.MonitorObject);
+
+			auto procIt = m_ProcessingThreads.find(path.MonitorObject);
+			if (procIt != m_ProcessingThreads.end() && procIt->second)
+			{
+				procIt->second->ClearExpectedMode();
+			}
 		}
 	}
 }

--- a/ZakoVDD/Rendering/SharedFrameExporter.cpp
+++ b/ZakoVDD/Rendering/SharedFrameExporter.cpp
@@ -269,7 +269,8 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 			(m_ExpectedWidth == 0 || srcDesc.Width == m_ExpectedWidth) &&
 			(m_ExpectedHeight == 0 || srcDesc.Height == m_ExpectedHeight);
 		const bool formatMatches =
-			m_ExpectedFormat == DXGI_FORMAT_UNKNOWN || srcDesc.Format == m_ExpectedFormat;
+			(m_ExpectedIsHdr && srcDesc.Format == DXGI_FORMAT_R16G16B16A16_FLOAT) ||
+			(!m_ExpectedIsHdr && srcDesc.Format != DXGI_FORMAT_UNKNOWN);
 
 		if (dimensionsMatch && formatMatches)
 		{
@@ -460,6 +461,7 @@ void SharedFrameExporter::UpdateHdrMetadata(bool isHdr, float maxNits, float min
 		// only require the exact FP16 format for HDR transitions. Sunshine
 		// still validates the actual texture descriptor before attaching.
 		m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
+		m_ExpectedIsHdr = m_PendingIsHdr;
 		m_ModePending = true;
 		m_LastPendingLogWidth = 0;
 		m_LastPendingLogHeight = 0;
@@ -492,6 +494,7 @@ void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
 		m_ExpectedWidth = 0;
 		m_ExpectedHeight = 0;
 		m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+		m_ExpectedIsHdr = false;
 		m_HasExpectedMode = false;
 		m_ModePending = true;
 		m_LastPendingLogWidth = 0;
@@ -505,8 +508,32 @@ void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
 	// Do not assume one specific SDR source format before the first frame;
 	// HDR is the only format family that needs an exact transition guard.
 	m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
+	m_ExpectedIsHdr = m_PendingIsHdr;
 	m_HasExpectedMode = true;
-	m_ModePending = true;
+
+	// An active mode commit is also delivered when the existing swap chain is
+	// reused without changing its actual mode. Do not unnecessarily close a
+	// ready channel in that case; a new processor has no cached textures and
+	// naturally remains pending until its first frame.
+	bool cachedChannelReady =
+		m_CachedWidth == width && m_CachedHeight == height &&
+		m_CachedFormat != DXGI_FORMAT_UNKNOWN;
+	if (cachedChannelReady)
+	{
+		for (const auto& texture : m_SharedTex)
+		{
+			if (!texture)
+			{
+				cachedChannelReady = false;
+				break;
+			}
+		}
+	}
+	const bool cachedFormatMatches =
+		m_ExpectedIsHdr ? m_CachedFormat == DXGI_FORMAT_R16G16B16A16_FLOAT :
+		                  m_CachedFormat != DXGI_FORMAT_UNKNOWN;
+	const bool modeWasAlreadyPending = m_ModePending;
+	m_ModePending = modeWasAlreadyPending || !cachedChannelReady || !cachedFormatMatches;
 	m_LastPendingLogWidth = 0;
 	m_LastPendingLogHeight = 0;
 	m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
@@ -527,6 +554,7 @@ void SharedFrameExporter::ClearExpectedMode()
 	m_ExpectedWidth = 0;
 	m_ExpectedHeight = 0;
 	m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	m_ExpectedIsHdr = false;
 	m_HasExpectedMode = false;
 	m_ModePending = true;
 	m_LastPendingLogWidth = 0;
@@ -551,7 +579,10 @@ bool SharedFrameExporter::IsReadyForExpectedMode() const
 		return false;
 	}
 
-	if (m_ExpectedFormat != DXGI_FORMAT_UNKNOWN && m_CachedFormat != m_ExpectedFormat)
+	const bool cachedFormatMatches =
+		m_ExpectedIsHdr ? m_CachedFormat == DXGI_FORMAT_R16G16B16A16_FLOAT :
+		                  m_CachedFormat != DXGI_FORMAT_UNKNOWN;
+	if (!cachedFormatMatches)
 	{
 		return false;
 	}

--- a/ZakoVDD/Rendering/SharedFrameExporter.cpp
+++ b/ZakoVDD/Rendering/SharedFrameExporter.cpp
@@ -262,6 +262,34 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		return;
 	}
 
+	bool modeBecameReady = false;
+	if (m_ModePending && m_HasExpectedMode)
+	{
+		const bool dimensionsMatch =
+			(m_ExpectedWidth == 0 || srcDesc.Width == m_ExpectedWidth) &&
+			(m_ExpectedHeight == 0 || srcDesc.Height == m_ExpectedHeight);
+		const bool formatMatches =
+			m_ExpectedFormat == DXGI_FORMAT_UNKNOWN || srcDesc.Format == m_ExpectedFormat;
+
+		if (dimensionsMatch && formatMatches)
+		{
+			modeBecameReady = true;
+		}
+		else if (m_LastPendingLogWidth != srcDesc.Width ||
+		         m_LastPendingLogHeight != srcDesc.Height ||
+		         m_LastPendingLogFormat != srcDesc.Format)
+		{
+			m_LastPendingLogWidth = srcDesc.Width;
+			m_LastPendingLogHeight = srcDesc.Height;
+			m_LastPendingLogFormat = srcDesc.Format;
+			VDD_LOG_DEBUG_STREAM("[VddExport] Ignoring non-matching frame while mode is pending monitor="
+			                     << m_MonitorIndex << " actual=" << srcDesc.Width << "x" << srcDesc.Height
+			                     << " fmt=" << srcDesc.Format
+			                     << " expected=" << m_ExpectedWidth << "x" << m_ExpectedHeight
+			                     << " fmt=" << m_ExpectedFormat);
+		}
+	}
+
 	// Best-effort acquire with 0 timeout. First try the normal empty-slot
 	// key (0) across the ring. If all slots are already published but unread
 	// (key 1), reclaim one and overwrite it. That keeps WGC-like "latest frame
@@ -355,6 +383,19 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		LARGE_INTEGER qpc{};
 		QueryPerformanceCounter(&qpc);
 		MetadataWriteScope metadataWrite(*this);
+		if (modeBecameReady)
+		{
+			// Publish the deferred mode/HDR state together with the first
+			// frame that made the channel ready. This also covers HDR
+			// luminance updates received while the mode was pending.
+			m_MetaView->Width = srcDesc.Width;
+			m_MetaView->Height = srcDesc.Height;
+			m_MetaView->DxgiFormat = srcDesc.Format;
+			m_MetaView->IsHdr = m_PendingIsHdr ? 1u : 0u;
+			m_MetaView->MaxNits = m_PendingMaxNits;
+			m_MetaView->MinNits = m_PendingMinNits;
+			m_MetaView->MaxFALL = m_PendingMaxFALL;
+		}
 		m_MetaView->FrameCounter++;
 		m_MetaView->LastPresentQpc = presentDisplayQpc ? presentDisplayQpc : static_cast<UINT64>(qpc.QuadPart);
 		m_MetaView->LastPublishQpc = static_cast<UINT64>(qpc.QuadPart);
@@ -377,6 +418,18 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		TeardownTexture();
 		return;
 	}
+	if (modeBecameReady)
+	{
+		// The channel becomes ready only after the matching frame was copied
+		// and successfully published to the keyed-mutex ring.
+		m_ModePending = false;
+		m_LastPendingLogWidth = 0;
+		m_LastPendingLogHeight = 0;
+		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+		VDD_LOG_INFO_STREAM("[VddExport] Shared frame channel ready monitor=" << m_MonitorIndex
+		                    << " " << srcDesc.Width << "x" << srcDesc.Height
+		                    << " fmt=" << srcDesc.Format);
+	}
 	m_NextPublishSlot = (selectedSlot + 1) % SharedFrameSlotCount;
 
 	if (m_FrameReadyEvent)
@@ -389,11 +442,34 @@ void SharedFrameExporter::UpdateHdrMetadata(bool isHdr, float maxNits, float min
 {
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
 
+	const bool formatChanged = m_PendingIsHdr != isHdr;
 	m_PendingIsHdr = isHdr;
 	m_PendingMaxNits = maxNits;
 	m_PendingMinNits = minNits;
 	m_PendingMaxFALL = maxFALL;
-	if (m_MetaView)
+
+	if (formatChanged)
+	{
+		if (!m_HasExpectedMode)
+		{
+			m_ExpectedWidth = m_CachedWidth;
+			m_ExpectedHeight = m_CachedHeight;
+			m_HasExpectedMode = true;
+		}
+		// The driver can receive more than one valid SDR DXGI format, so
+		// only require the exact FP16 format for HDR transitions. Sunshine
+		// still validates the actual texture descriptor before attaching.
+		m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
+		m_ModePending = true;
+		m_LastPendingLogWidth = 0;
+		m_LastPendingLogHeight = 0;
+		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+	}
+
+	// Defer the metadata update while a new mode/format is pending. The next
+	// PushFrame() publishes dimensions, format, and HDR fields together with
+	// the matching shared textures.
+	if (m_MetaView && !m_ModePending)
 	{
 		MetadataWriteScope metadataWrite(*this);
 		m_MetaView->IsHdr = isHdr ? 1u : 0u;
@@ -409,33 +485,85 @@ void SharedFrameExporter::UpdateHdrMetadata(bool isHdr, float maxNits, float min
 
 void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
 {
-	if (width == 0 || height == 0)
-	{
-		return;
-	}
-
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
 
-	D3D11_TEXTURE2D_DESC desc = {};
-	desc.Width = width;
-	desc.Height = height;
-	desc.Format = GuessMetadataFormat();
-
-	if (!EnsureEventAndMetadata(desc))
+	if (width == 0 || height == 0)
 	{
-		std::stringstream ss;
-		ss << "[VddExport] Failed to publish mode metadata for monitor=" << m_MonitorIndex
-		   << " " << width << "x" << height;
-		VDD_LOG_ERROR(ss.str().c_str());
+		m_ExpectedWidth = 0;
+		m_ExpectedHeight = 0;
+		m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+		m_HasExpectedMode = false;
+		m_ModePending = true;
+		m_LastPendingLogWidth = 0;
+		m_LastPendingLogHeight = 0;
+		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
 		return;
 	}
 
-	std::stringstream ss;
-	ss << "[VddExport] Published mode metadata monitor=" << m_MonitorIndex
-	   << " " << width << "x" << height
-	   << " fmt=" << desc.Format
-	   << " hdr=" << (m_PendingIsHdr ? 1 : 0);
-	VDD_LOG_INFO(ss.str().c_str());
+	m_ExpectedWidth = width;
+	m_ExpectedHeight = height;
+	// Do not assume one specific SDR source format before the first frame;
+	// HDR is the only format family that needs an exact transition guard.
+	m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
+	m_HasExpectedMode = true;
+	m_ModePending = true;
+	m_LastPendingLogWidth = 0;
+	m_LastPendingLogHeight = 0;
+	m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+
+	// CommitModes can arrive before the first frame of a replacement swap
+	// chain. Do not publish requested dimensions or format into a channel
+	// whose textures may still belong to the previous mode. PushFrame()
+	// publishes all metadata after the matching frame arrives.
+	VDD_LOG_INFO_STREAM("[VddExport] Armed expected mode monitor=" << m_MonitorIndex
+	                    << " " << width << "x" << height
+	                    << " fmt=" << m_ExpectedFormat
+	                    << "; waiting for the first matching frame");
+}
+
+void SharedFrameExporter::ClearExpectedMode()
+{
+	std::lock_guard<std::mutex> lock(m_ExportMutex);
+	m_ExpectedWidth = 0;
+	m_ExpectedHeight = 0;
+	m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	m_HasExpectedMode = false;
+	m_ModePending = true;
+	m_LastPendingLogWidth = 0;
+	m_LastPendingLogHeight = 0;
+	m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+}
+
+bool SharedFrameExporter::IsReadyForExpectedMode() const
+{
+	if (m_ModePending)
+	{
+		return false;
+	}
+
+	if (!m_HasExpectedMode)
+	{
+		return true;
+	}
+
+	if (m_CachedWidth != m_ExpectedWidth || m_CachedHeight != m_ExpectedHeight)
+	{
+		return false;
+	}
+
+	if (m_ExpectedFormat != DXGI_FORMAT_UNKNOWN && m_CachedFormat != m_ExpectedFormat)
+	{
+		return false;
+	}
+
+	for (const auto& texture : m_SharedTex)
+	{
+		if (!texture)
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 NTSTATUS SharedFrameExporter::OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
@@ -466,6 +594,10 @@ NTSTATUS SharedFrameExporter::OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQU
 	}
 
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
+	if (!IsReadyForExpectedMode())
+	{
+		return STATUS_DEVICE_NOT_READY;
+	}
 	if (!m_MetaMapping || !m_MetaView || !m_FrameReadyEvent)
 	{
 		return STATUS_DEVICE_NOT_READY;

--- a/ZakoVDD/Rendering/SharedFrameExporter.cpp
+++ b/ZakoVDD/Rendering/SharedFrameExporter.cpp
@@ -169,6 +169,23 @@ SharedFrameExporter::SharedFrameExporter(unsigned int monitorIndex, std::shared_
 {
 }
 
+bool SharedFrameExporter::IsHdrSurfaceColorSpace(DXGI_COLOR_SPACE_TYPE colorSpace)
+{
+	switch (colorSpace)
+	{
+	case DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709:
+	case DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020:
+	case DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020:
+	case DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020:
+	case DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020:
+	case DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020:
+	case DXGI_COLOR_SPACE_YCBCR_FULL_GHLG_TOPLEFT_P2020:
+		return true;
+	default:
+		return false;
+	}
+}
+
 SharedFrameExporter::~SharedFrameExporter()
 {
 	Teardown();
@@ -237,6 +254,8 @@ SharedFrameExporter::MetadataWriteScope::~MetadataWriteScope()
 }
 
 void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
+	                                DXGI_COLOR_SPACE_TYPE surfaceColorSpace,
+	                                bool hasSurfaceColorSpace,
                                     UINT64 presentDisplayQpc,
                                     UINT presentationFrameNumber,
                                     UINT dirtyRectCount)
@@ -256,39 +275,56 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 
 	D3D11_TEXTURE2D_DESC srcDesc = {};
 	srcTex->GetDesc(&srcDesc);
-
-	if (!EnsureSharedTexture(srcDesc))
-	{
-		return;
-	}
+	const bool isHdr = hasSurfaceColorSpace
+		? IsHdrSurfaceColorSpace(surfaceColorSpace)
+		: (m_HasExpectedHdrState ? m_ExpectedIsHdr : m_CachedIsHdr);
 
 	bool modeBecameReady = false;
-	if (m_ModePending && m_HasExpectedMode)
+	if (m_ModePending)
 	{
+		// An inactive path has no target mode. Discard any late frames from the
+		// retired swap chain instead of rebuilding a channel that cannot open.
+		if (!m_HasExpectedMode)
+		{
+			return;
+		}
+
 		const bool dimensionsMatch =
 			(m_ExpectedWidth == 0 || srcDesc.Width == m_ExpectedWidth) &&
 			(m_ExpectedHeight == 0 || srcDesc.Height == m_ExpectedHeight);
-		const bool formatMatches =
-			(m_ExpectedIsHdr && srcDesc.Format == DXGI_FORMAT_R16G16B16A16_FLOAT) ||
-			(!m_ExpectedIsHdr && srcDesc.Format != DXGI_FORMAT_UNKNOWN);
+		// SurfaceColorSpace describes the current desktop signal. Do not infer
+		// HDR from texture format: Windows can legitimately supply FP16 for SDR.
+		const bool colorSpaceMatches =
+			!m_HasExpectedHdrState || !hasSurfaceColorSpace || isHdr == m_ExpectedIsHdr;
 
-		if (dimensionsMatch && formatMatches)
+		if (!dimensionsMatch || !colorSpaceMatches)
 		{
-			modeBecameReady = true;
-		}
-		else if (m_LastPendingLogWidth != srcDesc.Width ||
+			if (m_LastPendingLogWidth != srcDesc.Width ||
 		         m_LastPendingLogHeight != srcDesc.Height ||
-		         m_LastPendingLogFormat != srcDesc.Format)
-		{
-			m_LastPendingLogWidth = srcDesc.Width;
-			m_LastPendingLogHeight = srcDesc.Height;
-			m_LastPendingLogFormat = srcDesc.Format;
-			VDD_LOG_DEBUG_STREAM("[VddExport] Ignoring non-matching frame while mode is pending monitor="
-			                     << m_MonitorIndex << " actual=" << srcDesc.Width << "x" << srcDesc.Height
-			                     << " fmt=" << srcDesc.Format
-			                     << " expected=" << m_ExpectedWidth << "x" << m_ExpectedHeight
-			                     << " fmt=" << m_ExpectedFormat);
+		         m_LastPendingLogFormat != srcDesc.Format ||
+		         m_LastPendingLogColorSpace != surfaceColorSpace)
+			{
+				m_LastPendingLogWidth = srcDesc.Width;
+				m_LastPendingLogHeight = srcDesc.Height;
+				m_LastPendingLogFormat = srcDesc.Format;
+				m_LastPendingLogColorSpace = surfaceColorSpace;
+				VDD_LOG_DEBUG_STREAM("[VddExport] Ignoring non-matching frame while mode is pending monitor="
+				                     << m_MonitorIndex << " actual=" << srcDesc.Width << "x" << srcDesc.Height
+				                     << " fmt=" << srcDesc.Format
+				                     << " colorspace=" << surfaceColorSpace
+				                     << " hdr=" << (isHdr ? 1 : 0)
+				                     << " expected=" << m_ExpectedWidth << "x" << m_ExpectedHeight
+				                     << " hdr=" << (m_HasExpectedHdrState ? (m_ExpectedIsHdr ? "1" : "0") : "unknown"));
+			}
+			return;
 		}
+
+		modeBecameReady = true;
+	}
+
+	if (!EnsureSharedTexture(srcDesc, isHdr))
+	{
+		return;
 	}
 
 	// Best-effort acquire with 0 timeout. First try the normal empty-slot
@@ -392,10 +428,16 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 			m_MetaView->Width = srcDesc.Width;
 			m_MetaView->Height = srcDesc.Height;
 			m_MetaView->DxgiFormat = srcDesc.Format;
-			m_MetaView->IsHdr = m_PendingIsHdr ? 1u : 0u;
+			m_MetaView->IsHdr = isHdr ? 1u : 0u;
 			m_MetaView->MaxNits = m_PendingMaxNits;
 			m_MetaView->MinNits = m_PendingMinNits;
 			m_MetaView->MaxFALL = m_PendingMaxFALL;
+		}
+		else
+		{
+			// Keep active HDR state tied to the frame's color space even if a
+			// mode commit reused the existing channel.
+			m_MetaView->IsHdr = isHdr ? 1u : 0u;
 		}
 		m_MetaView->FrameCounter++;
 		m_MetaView->LastPresentQpc = presentDisplayQpc ? presentDisplayQpc : static_cast<UINT64>(qpc.QuadPart);
@@ -419,6 +461,8 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		TeardownTexture();
 		return;
 	}
+	m_HasCachedColorSpace = hasSurfaceColorSpace;
+	m_CachedIsHdr = isHdr;
 	if (modeBecameReady)
 	{
 		// The channel becomes ready only after the matching frame was copied
@@ -427,9 +471,12 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 		m_LastPendingLogWidth = 0;
 		m_LastPendingLogHeight = 0;
 		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+		m_LastPendingLogColorSpace = DXGI_COLOR_SPACE_CUSTOM;
 		VDD_LOG_INFO_STREAM("[VddExport] Shared frame channel ready monitor=" << m_MonitorIndex
 		                    << " " << srcDesc.Width << "x" << srcDesc.Height
-		                    << " fmt=" << srcDesc.Format);
+		                    << " fmt=" << srcDesc.Format
+		                    << " colorspace=" << surfaceColorSpace
+		                    << " hdr=" << (isHdr ? 1 : 0));
 	}
 	m_NextPublishSlot = (selectedSlot + 1) % SharedFrameSlotCount;
 
@@ -439,53 +486,30 @@ void SharedFrameExporter::PushFrame(IDXGIResource* acquired,
 	}
 }
 
-void SharedFrameExporter::UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL)
+void SharedFrameExporter::UpdateHdrLuminanceMetadata(float maxNits, float minNits, float maxFALL)
 {
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
 
-	const bool formatChanged = m_PendingIsHdr != isHdr;
-	m_PendingIsHdr = isHdr;
 	m_PendingMaxNits = maxNits;
 	m_PendingMinNits = minNits;
 	m_PendingMaxFALL = maxFALL;
 
-	if (formatChanged)
-	{
-		if (!m_HasExpectedMode)
-		{
-			m_ExpectedWidth = m_CachedWidth;
-			m_ExpectedHeight = m_CachedHeight;
-			m_HasExpectedMode = true;
-		}
-		// The driver can receive more than one valid SDR DXGI format, so
-		// only require the exact FP16 format for HDR transitions. Sunshine
-		// still validates the actual texture descriptor before attaching.
-		m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
-		m_ExpectedIsHdr = m_PendingIsHdr;
-		m_ModePending = true;
-		m_LastPendingLogWidth = 0;
-		m_LastPendingLogHeight = 0;
-		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
-	}
-
-	// Defer the metadata update while a new mode/format is pending. The next
-	// PushFrame() publishes dimensions, format, and HDR fields together with
-	// the matching shared textures.
-	if (m_MetaView && !m_ModePending)
+	// Default HDR10 mastering metadata is available for every HDR-capable
+	// monitor, including while the active path is SDR. It must never change
+	// channel readiness or active HDR state.
+	if (m_MetaView)
 	{
 		MetadataWriteScope metadataWrite(*this);
-		m_MetaView->IsHdr = isHdr ? 1u : 0u;
 		m_MetaView->MaxNits = maxNits;
 		m_MetaView->MinNits = minNits;
 		m_MetaView->MaxFALL = maxFALL;
-		if (m_CachedFormat == DXGI_FORMAT_UNKNOWN)
-		{
-			m_MetaView->DxgiFormat = GuessMetadataFormat();
-		}
 	}
 }
 
-void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
+void SharedFrameExporter::PublishModeMetadata(UINT width,
+                                              UINT height,
+                                              bool hasExpectedHdrState,
+                                              bool expectedIsHdr)
 {
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
 
@@ -493,22 +517,21 @@ void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
 	{
 		m_ExpectedWidth = 0;
 		m_ExpectedHeight = 0;
-		m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+		m_HasExpectedHdrState = false;
 		m_ExpectedIsHdr = false;
 		m_HasExpectedMode = false;
 		m_ModePending = true;
 		m_LastPendingLogWidth = 0;
 		m_LastPendingLogHeight = 0;
 		m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+		m_LastPendingLogColorSpace = DXGI_COLOR_SPACE_CUSTOM;
 		return;
 	}
 
 	m_ExpectedWidth = width;
 	m_ExpectedHeight = height;
-	// Do not assume one specific SDR source format before the first frame;
-	// HDR is the only format family that needs an exact transition guard.
-	m_ExpectedFormat = m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_UNKNOWN;
-	m_ExpectedIsHdr = m_PendingIsHdr;
+	m_HasExpectedHdrState = hasExpectedHdrState;
+	m_ExpectedIsHdr = expectedIsHdr;
 	m_HasExpectedMode = true;
 
 	// An active mode commit is also delivered when the existing swap chain is
@@ -529,23 +552,23 @@ void SharedFrameExporter::PublishModeMetadata(UINT width, UINT height)
 			}
 		}
 	}
-	const bool cachedFormatMatches =
-		m_ExpectedIsHdr ? m_CachedFormat == DXGI_FORMAT_R16G16B16A16_FLOAT :
-		                  m_CachedFormat != DXGI_FORMAT_UNKNOWN;
+	const bool cachedHdrMatches =
+		!m_HasExpectedHdrState || !m_HasCachedColorSpace || m_CachedIsHdr == m_ExpectedIsHdr;
 	const bool modeWasAlreadyPending = m_ModePending;
-	m_ModePending = modeWasAlreadyPending || !cachedChannelReady || !cachedFormatMatches;
+	m_ModePending = modeWasAlreadyPending || !cachedChannelReady || !cachedHdrMatches;
 	m_LastPendingLogWidth = 0;
 	m_LastPendingLogHeight = 0;
 	m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+	m_LastPendingLogColorSpace = DXGI_COLOR_SPACE_CUSTOM;
 
 	// CommitModes can arrive before the first frame of a replacement swap
 	// chain. Do not publish requested dimensions or format into a channel
 	// whose textures may still belong to the previous mode. PushFrame()
 	// publishes all metadata after the matching frame arrives.
-	VDD_LOG_INFO_STREAM("[VddExport] Armed expected mode monitor=" << m_MonitorIndex
+	VDD_LOG_INFO_STREAM("[VddExport] Committed expected mode monitor=" << m_MonitorIndex
 	                    << " " << width << "x" << height
-	                    << " fmt=" << m_ExpectedFormat
-	                    << "; waiting for the first matching frame");
+	                    << " hdr=" << (m_HasExpectedHdrState ? (m_ExpectedIsHdr ? "1" : "0") : "unknown")
+	                    << " channel_pending=" << (m_ModePending ? 1 : 0));
 }
 
 void SharedFrameExporter::ClearExpectedMode()
@@ -553,13 +576,14 @@ void SharedFrameExporter::ClearExpectedMode()
 	std::lock_guard<std::mutex> lock(m_ExportMutex);
 	m_ExpectedWidth = 0;
 	m_ExpectedHeight = 0;
-	m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	m_HasExpectedHdrState = false;
 	m_ExpectedIsHdr = false;
 	m_HasExpectedMode = false;
 	m_ModePending = true;
 	m_LastPendingLogWidth = 0;
 	m_LastPendingLogHeight = 0;
 	m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+	m_LastPendingLogColorSpace = DXGI_COLOR_SPACE_CUSTOM;
 }
 
 bool SharedFrameExporter::IsReadyForExpectedMode() const
@@ -579,10 +603,9 @@ bool SharedFrameExporter::IsReadyForExpectedMode() const
 		return false;
 	}
 
-	const bool cachedFormatMatches =
-		m_ExpectedIsHdr ? m_CachedFormat == DXGI_FORMAT_R16G16B16A16_FLOAT :
-		                  m_CachedFormat != DXGI_FORMAT_UNKNOWN;
-	if (!cachedFormatMatches)
+	const bool cachedHdrMatches =
+		!m_HasExpectedHdrState || !m_HasCachedColorSpace || m_CachedIsHdr == m_ExpectedIsHdr;
+	if (!cachedHdrMatches)
 	{
 		return false;
 	}
@@ -668,12 +691,7 @@ NTSTATUS SharedFrameExporter::OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQU
 	return status;
 }
 
-DXGI_FORMAT SharedFrameExporter::GuessMetadataFormat() const
-{
-	return m_PendingIsHdr ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_B8G8R8A8_UNORM;
-}
-
-bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc)
+bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc, bool isHdr)
 {
 	bool allSlotsReady = true;
 	for (const auto& tex : m_SharedTex)
@@ -790,7 +808,7 @@ bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDes
 	}
 	LocalFree(sd);
 
-	if (!EnsureEventAndMetadata(srcDesc))
+	if (!EnsureEventAndMetadata(srcDesc, isHdr))
 	{
 		TeardownTexture();
 		return false;
@@ -810,7 +828,7 @@ bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDes
 	return true;
 }
 
-bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& srcDesc)
+bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& srcDesc, bool isHdr)
 {
 	SECURITY_ATTRIBUTES sa = {};
 	PSECURITY_DESCRIPTOR sd = nullptr;
@@ -897,7 +915,7 @@ bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& src
 	m_MetaView->Width = srcDesc.Width;
 	m_MetaView->Height = srcDesc.Height;
 	m_MetaView->DxgiFormat = srcDesc.Format;
-	m_MetaView->IsHdr = m_PendingIsHdr ? 1u : 0u;
+	m_MetaView->IsHdr = isHdr ? 1u : 0u;
 	m_MetaView->MaxNits = m_PendingMaxNits;
 	m_MetaView->MinNits = m_PendingMinNits;
 	m_MetaView->MaxFALL = m_PendingMaxFALL;
@@ -941,6 +959,8 @@ void SharedFrameExporter::TeardownTexture()
 	m_CachedWidth = 0;
 	m_CachedHeight = 0;
 	m_CachedFormat = DXGI_FORMAT_UNKNOWN;
+	m_HasCachedColorSpace = false;
+	m_CachedIsHdr = false;
 }
 
 void SharedFrameExporter::Teardown()

--- a/ZakoVDD/Rendering/SharedFrameExporter.h
+++ b/ZakoVDD/Rendering/SharedFrameExporter.h
@@ -27,6 +27,7 @@ public:
 	               UINT dirtyRectCount = 0);
 	void UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL);
 	void PublishModeMetadata(UINT width, UINT height);
+	void ClearExpectedMode();
 	NTSTATUS OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
 	                          HANDLE targetProcess,
 	                          VDD_FRAME_CHANNEL_OPEN_RESPONSE& response);
@@ -35,6 +36,7 @@ private:
 	DXGI_FORMAT GuessMetadataFormat() const;
 	bool EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc);
 	bool EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& srcDesc);
+	bool IsReadyForExpectedMode() const;
 	void BeginMetadataWrite();
 	void EndMetadataWrite();
 	void BumpChannelGeneration();
@@ -67,6 +69,18 @@ private:
 	UINT m_CachedWidth = 0;
 	UINT m_CachedHeight = 0;
 	DXGI_FORMAT m_CachedFormat = DXGI_FORMAT_UNKNOWN;
+	// A committed display mode is only a request. The shared texture becomes
+	// authoritative after the first frame from the replacement swap chain
+	// arrives. Keep the expected mode and readiness state separate so
+	// OpenFrameChannel() cannot expose a previous mode during that transition.
+	UINT m_ExpectedWidth = 0;
+	UINT m_ExpectedHeight = 0;
+	DXGI_FORMAT m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	bool m_HasExpectedMode = false;
+	bool m_ModePending = false;
+	UINT m_LastPendingLogWidth = 0;
+	UINT m_LastPendingLogHeight = 0;
+	DXGI_FORMAT m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
 	// Metadata writes are serialized by m_ExportMutex and must be wrapped in
 	// MetadataWriteScope so consumers never accept a partially updated snapshot.
 	UINT16 m_ChannelGeneration = 1;

--- a/ZakoVDD/Rendering/SharedFrameExporter.h
+++ b/ZakoVDD/Rendering/SharedFrameExporter.h
@@ -76,6 +76,7 @@ private:
 	UINT m_ExpectedWidth = 0;
 	UINT m_ExpectedHeight = 0;
 	DXGI_FORMAT m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	bool m_ExpectedIsHdr = false;
 	bool m_HasExpectedMode = false;
 	bool m_ModePending = false;
 	UINT m_LastPendingLogWidth = 0;

--- a/ZakoVDD/Rendering/SharedFrameExporter.h
+++ b/ZakoVDD/Rendering/SharedFrameExporter.h
@@ -22,21 +22,23 @@ public:
 	~SharedFrameExporter();
 
 	void PushFrame(IDXGIResource* acquired,
+	               DXGI_COLOR_SPACE_TYPE surfaceColorSpace,
+	               bool hasSurfaceColorSpace,
 	               UINT64 presentDisplayQpc = 0,
 	               UINT presentationFrameNumber = 0,
 	               UINT dirtyRectCount = 0);
-	void UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL);
-	void PublishModeMetadata(UINT width, UINT height);
+	void UpdateHdrLuminanceMetadata(float maxNits, float minNits, float maxFALL);
+	void PublishModeMetadata(UINT width, UINT height, bool hasExpectedHdrState, bool expectedIsHdr);
 	void ClearExpectedMode();
 	NTSTATUS OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
 	                          HANDLE targetProcess,
 	                          VDD_FRAME_CHANNEL_OPEN_RESPONSE& response);
 
 private:
-	DXGI_FORMAT GuessMetadataFormat() const;
-	bool EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc);
-	bool EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& srcDesc);
+	bool EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDesc, bool isHdr);
+	bool EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& srcDesc, bool isHdr);
 	bool IsReadyForExpectedMode() const;
+	static bool IsHdrSurfaceColorSpace(DXGI_COLOR_SPACE_TYPE colorSpace);
 	void BeginMetadataWrite();
 	void EndMetadataWrite();
 	void BumpChannelGeneration();
@@ -69,25 +71,27 @@ private:
 	UINT m_CachedWidth = 0;
 	UINT m_CachedHeight = 0;
 	DXGI_FORMAT m_CachedFormat = DXGI_FORMAT_UNKNOWN;
+	bool m_HasCachedColorSpace = false;
+	bool m_CachedIsHdr = false;
 	// A committed display mode is only a request. The shared texture becomes
 	// authoritative after the first frame from the replacement swap chain
 	// arrives. Keep the expected mode and readiness state separate so
 	// OpenFrameChannel() cannot expose a previous mode during that transition.
 	UINT m_ExpectedWidth = 0;
 	UINT m_ExpectedHeight = 0;
-	DXGI_FORMAT m_ExpectedFormat = DXGI_FORMAT_UNKNOWN;
+	bool m_HasExpectedHdrState = false;
 	bool m_ExpectedIsHdr = false;
 	bool m_HasExpectedMode = false;
 	bool m_ModePending = false;
 	UINT m_LastPendingLogWidth = 0;
 	UINT m_LastPendingLogHeight = 0;
 	DXGI_FORMAT m_LastPendingLogFormat = DXGI_FORMAT_UNKNOWN;
+	DXGI_COLOR_SPACE_TYPE m_LastPendingLogColorSpace = DXGI_COLOR_SPACE_CUSTOM;
 	// Metadata writes are serialized by m_ExportMutex and must be wrapped in
 	// MetadataWriteScope so consumers never accept a partially updated snapshot.
 	UINT16 m_ChannelGeneration = 1;
 	UINT16 m_MetadataSequenceCounter = 0;
 
-	bool m_PendingIsHdr = false;
 	float m_PendingMaxNits = 0.0f;
 	float m_PendingMinNits = 0.0f;
 	float m_PendingMaxFALL = 0.0f;

--- a/ZakoVDD/Rendering/SwapChainProcessor.cpp
+++ b/ZakoVDD/Rendering/SwapChainProcessor.cpp
@@ -93,7 +93,9 @@ SwapChainProcessor::~SwapChainProcessor()
 	}
 }
 
-void SwapChainProcessor::PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_INFO& mode)
+void SwapChainProcessor::PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_INFO& mode,
+                                             bool hasExpectedHdrState,
+                                             bool expectedIsHdr)
 {
 	if (!m_Exporter)
 	{
@@ -102,7 +104,7 @@ void SwapChainProcessor::PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_IN
 
 	const UINT width = mode.activeSize.cx ? static_cast<UINT>(mode.activeSize.cx) : static_cast<UINT>(mode.totalSize.cx);
 	const UINT height = mode.activeSize.cy ? static_cast<UINT>(mode.activeSize.cy) : static_cast<UINT>(mode.totalSize.cy);
-	m_Exporter->PublishModeMetadata(width, height);
+	m_Exporter->PublishModeMetadata(width, height, hasExpectedHdrState, expectedIsHdr);
 }
 
 void SwapChainProcessor::ClearExpectedMode()
@@ -113,14 +115,14 @@ void SwapChainProcessor::ClearExpectedMode()
 	}
 }
 
-void SwapChainProcessor::UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL)
+void SwapChainProcessor::UpdateHdrLuminanceMetadata(float maxNits, float minNits, float maxFALL)
 {
 	if (!m_Exporter)
 	{
 		return;
 	}
 
-	m_Exporter->UpdateHdrMetadata(isHdr, maxNits, minNits, maxFALL);
+	m_Exporter->UpdateHdrLuminanceMetadata(maxNits, minNits, maxFALL);
 }
 
 NTSTATUS SwapChainProcessor::OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
@@ -276,6 +278,8 @@ void SwapChainProcessor::RunCore()
 		UINT64 presentDisplayQpc = 0;
 		UINT presentationFrameNumber = 0;
 		UINT dirtyRectCount = 0;
+		DXGI_COLOR_SPACE_TYPE surfaceColorSpace = DXGI_COLOR_SPACE_CUSTOM;
+		bool hasSurfaceColorSpace = false;
 
 		if (useBuffer2)
 		{
@@ -285,6 +289,8 @@ void SwapChainProcessor::RunCore()
 			presentDisplayQpc = Buffer.MetaData.PresentDisplayQPCTime;
 			presentationFrameNumber = Buffer.MetaData.PresentationFrameNumber;
 			dirtyRectCount = Buffer.MetaData.DirtyRectCount;
+			surfaceColorSpace = Buffer.MetaData.SurfaceColorSpace;
+			hasSurfaceColorSpace = surfaceColorSpace != DXGI_COLOR_SPACE_CUSTOM;
 		}
 		else
 		{
@@ -333,6 +339,8 @@ void SwapChainProcessor::RunCore()
 			if (m_Exporter)
 			{
 				m_Exporter->PushFrame(AcquiredBuffer.Get(),
+				                      surfaceColorSpace,
+				                      hasSurfaceColorSpace,
 				                      presentDisplayQpc,
 				                      presentationFrameNumber,
 				                      dirtyRectCount);

--- a/ZakoVDD/Rendering/SwapChainProcessor.cpp
+++ b/ZakoVDD/Rendering/SwapChainProcessor.cpp
@@ -105,6 +105,14 @@ void SwapChainProcessor::PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_IN
 	m_Exporter->PublishModeMetadata(width, height);
 }
 
+void SwapChainProcessor::ClearExpectedMode()
+{
+	if (m_Exporter)
+	{
+		m_Exporter->ClearExpectedMode();
+	}
+}
+
 void SwapChainProcessor::UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL)
 {
 	if (!m_Exporter)

--- a/ZakoVDD/Rendering/SwapChainProcessor.h
+++ b/ZakoVDD/Rendering/SwapChainProcessor.h
@@ -24,6 +24,7 @@ namespace Microsoft
 			~SwapChainProcessor();
 
 			void PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_INFO &mode);
+			void ClearExpectedMode();
 			void UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL);
 			NTSTATUS OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
 			                          HANDLE targetProcess,

--- a/ZakoVDD/Rendering/SwapChainProcessor.h
+++ b/ZakoVDD/Rendering/SwapChainProcessor.h
@@ -23,9 +23,11 @@ namespace Microsoft
 			SwapChainProcessor(IDDCX_SWAPCHAIN hSwapChain, std::shared_ptr<Direct3DDevice> Device, HANDLE NewFrameEvent, unsigned int MonitorIndex);
 			~SwapChainProcessor();
 
-			void PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_INFO &mode);
+			void PublishModeMetadata(const DISPLAYCONFIG_VIDEO_SIGNAL_INFO &mode,
+			                         bool hasExpectedHdrState,
+			                         bool expectedIsHdr);
 			void ClearExpectedMode();
-			void UpdateHdrMetadata(bool isHdr, float maxNits, float minNits, float maxFALL);
+			void UpdateHdrLuminanceMetadata(float maxNits, float minNits, float maxFALL);
 			NTSTATUS OpenFrameChannel(const VDD_FRAME_CHANNEL_OPEN_REQUEST& request,
 			                          HANDLE targetProcess,
 			                          VDD_FRAME_CHANNEL_OPEN_RESPONSE& response);


### PR DESCRIPTION
## 改了啥呀

- Keep the sealed frame channel unavailable until a frame matches the committed dimensions and HDR state.
- Treat `EVT_IDD_CX_MONITOR_SET_DEFAULT_HDR_METADATA` as default mastering-luminance data only; it no longer toggles active HDR state.
- Derive expected HDR from `CommitModes2` wire color space and actual HDR from each acquired surface color space.
- Reject stale transition frames before rebuilding or copying shared textures, so an old swap chain cannot churn or replace the pending producer.
- Recognize scRGB, PQ, and HLG HDR color spaces without guessing HDR from the texture format; valid SDR FP16 frames remain accepted.
- Keep inactive paths closed and preserve the existing rate-limited transition diagnostics.

## 为啥要改

The default HDR metadata callback runs for every HDR-capable monitor before `CommitModes2`, including while the active path is SDR. The old code treated that callback as `isHdr=true`, so this little 杂鱼 bug made readiness wait for an HDR/FP16 producer while Windows was actually publishing an SDR BGRA8 frame. Sunshine then kept receiving `STATUS_DEVICE_NOT_READY` and eventually reported no valid sealed VDD producer.

Texture format is not a reliable active-HDR signal either: Windows can legitimately supply FP16 SDR surfaces. The committed wire color space is the requested state, and the per-frame surface color space is the produced state, so readiness now compares those two authoritative sources.

## 验证

- `MSBuild ZakoVDD.sln /m /t:Build /p:Configuration=Release /p:Platform=x64`
  - C++ compilation and code analysis, linking, Universal API validation, signing, signability, and catalog generation completed.
  - The WDK MSBuild target still prints the local environment's existing x86 `InfVerif.dll` loader exception; running the shipped x64 `InfVerif.exe` directly returned 0 with only the existing warning 2084 for `WUDFRd.sys`.
- `git diff --check`
- Direct sealed-channel probe at `3840x2160`:
  - SDR: `fmt=87 hdr=0`
  - same-resolution HDR transition: `fmt=10 hdr=1`
  - transition back to SDR: `fmt=87 hdr=0`
- Real remote Sunshine resume opened sealed monitor 0 at `3840x2160 fmt=87 hdr=false` and reached `[vdd] backend ready` without the legacy `Meta_*` fallback.
- Final Release x64 DLL is validly test-signed; SHA-256: `709D2F2B13E4E8DEC0E8D0D4AC48C0C0DCBEA5FB9909BBBF096D1076961290EB`.