### PR TITLE
fix(vdd): harden control and frame channels

### DIFF
--- a/Common/Include/vdd_control_ioctl.h
+++ b/Common/Include/vdd_control_ioctl.h
@@ -28,7 +28,8 @@
  *
  *   `IOCTL_VDD_OPEN_FRAME_CHANNEL` asks the driver to duplicate an unnamed
  *   producer-owned frame channel into the requesting Sunshine process. The
- *   returned handle values are valid only in `TargetProcessId`.
+ *   returned handle values are valid only in `TargetProcessId`, which must be
+ *   the process that issued the IOCTL.
  *
  *   `DesiredSlots` is a compatibility guard, not a request for the driver to
  *   resize its producer ring. Use 0 for the driver default, or the exact

--- a/ZakoVDD/Callbacks/IddCallbacks.cpp
+++ b/ZakoVDD/Callbacks/IddCallbacks.cpp
@@ -33,6 +33,28 @@ static ColourSettingsSnapshot GetColourSettingsSnapshot()
 	return {ColourFormat, SDRCOLOUR, HDRCOLOUR};
 }
 
+template <typename BitsField>
+static void ApplyBitsPerComponent(BitsField &target, const ColourSettingsSnapshot &colourSettings)
+{
+	const auto combined = colourSettings.sdr | colourSettings.hdr;
+	if (colourSettings.format == L"YCbCr444")
+	{
+		target.YCbCr444 = combined;
+	}
+	else if (colourSettings.format == L"YCbCr422")
+	{
+		target.YCbCr422 = combined;
+	}
+	else if (colourSettings.format == L"YCbCr420")
+	{
+		target.YCbCr420 = combined;
+	}
+	else
+	{
+		target.Rgb = combined;
+	}
+}
+
 _Use_decl_annotations_
 	NTSTATUS
 	VirtualDisplayDriverAdapterInitFinished(IDDCX_ADAPTER AdapterObject, const IDARG_IN_ADAPTER_INIT_FINISHED *pInArgs)
@@ -178,27 +200,7 @@ void CreateTargetMode2(IDDCX_TARGET_MODE2 &Mode, UINT Width, UINT Height, UINT V
 
 	Mode.Size = sizeof(Mode);
 	const auto colourSettings = GetColourSettingsSnapshot();
-
-	if (colourSettings.format == L"RGB")
-	{
-		Mode.BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr444")
-	{
-		Mode.BitsPerComponent.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr422")
-	{
-		Mode.BitsPerComponent.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr420")
-	{
-		Mode.BitsPerComponent.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else
-	{
-		Mode.BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
-	}
+	ApplyBitsPerComponent(Mode.BitsPerComponent, colourSettings);
 
 	VDD_LOG_DEBUG_STREAM("IDDCX_TARGET_MODE2 configured with Size: " << Mode.Size
 	                     << " and colour format " << WStringToString(colourSettings.format));
@@ -292,27 +294,7 @@ _Use_decl_annotations_
 
 	pOutArgs->TargetCaps = IDDCX_TARGET_CAPS_HIGH_COLOR_SPACE | IDDCX_TARGET_CAPS_WIDE_COLOR_SPACE;
 	const auto colourSettings = GetColourSettingsSnapshot();
-
-	if (colourSettings.format == L"RGB")
-	{
-		pOutArgs->DitheringSupport.Rgb = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr444")
-	{
-		pOutArgs->DitheringSupport.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr422")
-	{
-		pOutArgs->DitheringSupport.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else if (colourSettings.format == L"YCbCr420")
-	{
-		pOutArgs->DitheringSupport.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
-	}
-	else
-	{
-		pOutArgs->DitheringSupport.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
-	}
+	ApplyBitsPerComponent(pOutArgs->DitheringSupport, colourSettings);
 
 	VDD_LOG_DEBUG_STREAM("Target capabilities set to: " << pOutArgs->TargetCaps
 	                     << "\nDithering support colour format set to: " << WStringToString(colourSettings.format));
@@ -436,27 +418,7 @@ _Use_decl_annotations_
 			monitorModesOutput[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE2);
 			monitorModesOutput[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
 			monitorModesOutput[ModeIndex].MonitorVideoSignalInfo = knownMonitorModes[ModeIndex];
-
-			if (colourSettings.format == L"RGB")
-			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr;
-			}
-			else if (colourSettings.format == L"YCbCr444")
-			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
-			}
-			else if (colourSettings.format == L"YCbCr422")
-			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
-			}
-			else if (colourSettings.format == L"YCbCr420")
-			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
-			}
-			else
-			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
-			}
+			ApplyBitsPerComponent(monitorModesOutput[ModeIndex].BitsPerComponent, colourSettings);
 
 		}
 

--- a/ZakoVDD/Callbacks/IddCallbacks.cpp
+++ b/ZakoVDD/Callbacks/IddCallbacks.cpp
@@ -16,10 +16,22 @@ using namespace std;
 using namespace Microsoft::IndirectDisp;
 
 extern std::mutex g_DataMutex;
-extern std::vector<DISPLAYCONFIG_VIDEO_SIGNAL_INFO> s_KnownMonitorModes2;
 extern std::wstring ColourFormat;
 extern IDDCX_BITS_PER_COMPONENT SDRCOLOUR;
 extern IDDCX_BITS_PER_COMPONENT HDRCOLOUR;
+
+struct ColourSettingsSnapshot
+{
+	wstring format;
+	IDDCX_BITS_PER_COMPONENT sdr = IDDCX_BITS_PER_COMPONENT_8;
+	IDDCX_BITS_PER_COMPONENT hdr = IDDCX_BITS_PER_COMPONENT_10;
+};
+
+static ColourSettingsSnapshot GetColourSettingsSnapshot()
+{
+	lock_guard<mutex> dataLock(g_DataMutex);
+	return {ColourFormat, SDRCOLOUR, HDRCOLOUR};
+}
 
 _Use_decl_annotations_
 	NTSTATUS
@@ -68,12 +80,11 @@ VirtualDisplayDriverParseMonitorDescription(const IDARG_IN_PARSEMONITORDESCRIPTI
 		localModes = monitorModes;
 	}
 
-	// Clear previous monitor modes to prevent accumulation on reload
-	s_KnownMonitorModes2.clear();
-
-	for (int i = 0; i < localModes.size(); i++)
+	vector<DISPLAYCONFIG_VIDEO_SIGNAL_INFO> knownMonitorModes;
+	knownMonitorModes.reserve(localModes.size());
+	for (const auto &mode : localModes)
 	{
-		s_KnownMonitorModes2.push_back(dispinfo(std::get<0>(localModes[i]), std::get<1>(localModes[i]), std::get<2>(localModes[i]), std::get<3>(localModes[i])));
+		knownMonitorModes.push_back(dispinfo(get<0>(mode), get<1>(mode), get<2>(mode), get<3>(mode)));
 	}
 	pOutArgs->MonitorModeBufferOutputCount = (UINT)localModes.size();
 
@@ -99,7 +110,7 @@ VirtualDisplayDriverParseMonitorDescription(const IDARG_IN_PARSEMONITORDESCRIPTI
 		{
 			monitorModesOutput[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE);
 			monitorModesOutput[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
-			monitorModesOutput[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
+			monitorModesOutput[ModeIndex].MonitorVideoSignalInfo = knownMonitorModes[ModeIndex];
 		}
 
 		// Set the preferred mode as represented in the EDID
@@ -166,30 +177,31 @@ void CreateTargetMode2(IDDCX_TARGET_MODE2 &Mode, UINT Width, UINT Height, UINT V
 	                     << ", VSyncDen: " << VSyncDen);
 
 	Mode.Size = sizeof(Mode);
+	const auto colourSettings = GetColourSettingsSnapshot();
 
-	if (ColourFormat == L"RGB")
+	if (colourSettings.format == L"RGB")
 	{
-		Mode.BitsPerComponent.Rgb = SDRCOLOUR | HDRCOLOUR;
+		Mode.BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr444")
+	else if (colourSettings.format == L"YCbCr444")
 	{
-		Mode.BitsPerComponent.YCbCr444 = SDRCOLOUR | HDRCOLOUR;
+		Mode.BitsPerComponent.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr422")
+	else if (colourSettings.format == L"YCbCr422")
 	{
-		Mode.BitsPerComponent.YCbCr422 = SDRCOLOUR | HDRCOLOUR;
+		Mode.BitsPerComponent.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr420")
+	else if (colourSettings.format == L"YCbCr420")
 	{
-		Mode.BitsPerComponent.YCbCr420 = SDRCOLOUR | HDRCOLOUR;
+		Mode.BitsPerComponent.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
 	}
 	else
 	{
-		Mode.BitsPerComponent.Rgb = SDRCOLOUR | HDRCOLOUR; // Default to RGB
+		Mode.BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
 	}
 
 	VDD_LOG_DEBUG_STREAM("IDDCX_TARGET_MODE2 configured with Size: " << Mode.Size
-	                     << " and colour format " << WStringToString(ColourFormat));
+	                     << " and colour format " << WStringToString(colourSettings.format));
 
 	CreateTargetMode(Mode.TargetVideoSignalInfo.targetVideoSignalInfo, Width, Height, VSyncNum, VSyncDen);
 }
@@ -279,30 +291,31 @@ _Use_decl_annotations_
 	UNREFERENCED_PARAMETER(pInArgs);
 
 	pOutArgs->TargetCaps = IDDCX_TARGET_CAPS_HIGH_COLOR_SPACE | IDDCX_TARGET_CAPS_WIDE_COLOR_SPACE;
+	const auto colourSettings = GetColourSettingsSnapshot();
 
-	if (ColourFormat == L"RGB")
+	if (colourSettings.format == L"RGB")
 	{
-		pOutArgs->DitheringSupport.Rgb = SDRCOLOUR | HDRCOLOUR;
+		pOutArgs->DitheringSupport.Rgb = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr444")
+	else if (colourSettings.format == L"YCbCr444")
 	{
-		pOutArgs->DitheringSupport.YCbCr444 = SDRCOLOUR | HDRCOLOUR;
+		pOutArgs->DitheringSupport.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr422")
+	else if (colourSettings.format == L"YCbCr422")
 	{
-		pOutArgs->DitheringSupport.YCbCr422 = SDRCOLOUR | HDRCOLOUR;
+		pOutArgs->DitheringSupport.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
 	}
-	else if (ColourFormat == L"YCbCr420")
+	else if (colourSettings.format == L"YCbCr420")
 	{
-		pOutArgs->DitheringSupport.YCbCr420 = SDRCOLOUR | HDRCOLOUR;
+		pOutArgs->DitheringSupport.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
 	}
 	else
 	{
-		pOutArgs->DitheringSupport.Rgb = SDRCOLOUR | HDRCOLOUR; // Default to RGB
+		pOutArgs->DitheringSupport.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
 	}
 
 	VDD_LOG_DEBUG_STREAM("Target capabilities set to: " << pOutArgs->TargetCaps
-	                     << "\nDithering support colour format set to: " << WStringToString(ColourFormat));
+	                     << "\nDithering support colour format set to: " << WStringToString(colourSettings.format));
 
 	return STATUS_SUCCESS;
 }
@@ -371,9 +384,11 @@ _Use_decl_annotations_
 {
 	// Take a local snapshot of monitorModes under lock to prevent data races
 	vector<tuple<int, int, int, int>> localModes;
+	ColourSettingsSnapshot colourSettings;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
 		localModes = monitorModes;
+		colourSettings = {ColourFormat, SDRCOLOUR, HDRCOLOUR};
 	}
 
 	VDD_LOG_DEBUG_STREAM("Parsing monitor description:"
@@ -393,12 +408,11 @@ _Use_decl_annotations_
 		return logStream.str();
 	});
 
-	// Clear previous monitor modes to prevent accumulation on reload
-	s_KnownMonitorModes2.clear();
-
-	for (int i = 0; i < localModes.size(); i++)
+	vector<DISPLAYCONFIG_VIDEO_SIGNAL_INFO> knownMonitorModes;
+	knownMonitorModes.reserve(localModes.size());
+	for (const auto &mode : localModes)
 	{
-		s_KnownMonitorModes2.push_back(dispinfo(std::get<0>(localModes[i]), std::get<1>(localModes[i]), std::get<2>(localModes[i]), std::get<3>(localModes[i])));
+		knownMonitorModes.push_back(dispinfo(get<0>(mode), get<1>(mode), get<2>(mode), get<3>(mode)));
 	}
 	pOutArgs->MonitorModeBufferOutputCount = (UINT)localModes.size();
 
@@ -421,27 +435,27 @@ _Use_decl_annotations_
 		{
 			monitorModesOutput[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE2);
 			monitorModesOutput[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
-			monitorModesOutput[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
+			monitorModesOutput[ModeIndex].MonitorVideoSignalInfo = knownMonitorModes[ModeIndex];
 
-			if (ColourFormat == L"RGB")
+			if (colourSettings.format == L"RGB")
 			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = SDRCOLOUR | HDRCOLOUR;
+				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr;
 			}
-			else if (ColourFormat == L"YCbCr444")
+			else if (colourSettings.format == L"YCbCr444")
 			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr444 = SDRCOLOUR | HDRCOLOUR;
+				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr444 = colourSettings.sdr | colourSettings.hdr;
 			}
-			else if (ColourFormat == L"YCbCr422")
+			else if (colourSettings.format == L"YCbCr422")
 			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr422 = SDRCOLOUR | HDRCOLOUR;
+				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr422 = colourSettings.sdr | colourSettings.hdr;
 			}
-			else if (ColourFormat == L"YCbCr420")
+			else if (colourSettings.format == L"YCbCr420")
 			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr420 = SDRCOLOUR | HDRCOLOUR;
+				monitorModesOutput[ModeIndex].BitsPerComponent.YCbCr420 = colourSettings.sdr | colourSettings.hdr;
 			}
 			else
 			{
-				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = SDRCOLOUR | HDRCOLOUR; // Default to RGB
+				monitorModesOutput[ModeIndex].BitsPerComponent.Rgb = colourSettings.sdr | colourSettings.hdr; // Default to RGB
 			}
 
 		}
@@ -455,7 +469,7 @@ _Use_decl_annotations_
 				logStream << "\n  ModeIndex: " << ModeIndex
 				          << "\n    Size: " << monitorModesOutput[ModeIndex].Size
 				          << "\n    Origin: " << monitorModesOutput[ModeIndex].Origin
-				          << "\n    Colour Format: " << WStringToString(ColourFormat);
+				          << "\n    Colour Format: " << WStringToString(colourSettings.format);
 			}
 			return logStream.str();
 		});
@@ -481,9 +495,11 @@ _Use_decl_annotations_
 
 	// Take a local snapshot of monitorModes under lock to prevent data races
 	vector<tuple<int, int, int, int>> localModes;
+	wstring colourFormat;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
 		localModes = monitorModes;
+		colourFormat = ColourFormat;
 	}
 
 	vector<IDDCX_TARGET_MODE2> TargetModes(localModes.size());
@@ -527,7 +543,7 @@ _Use_decl_annotations_
 			{
 				logStream << "\n  TargetModeIndex: " << i
 				          << "\n    Size: " << TargetModes[i].Size
-				          << "\n    ColourFormat: " << WStringToString(ColourFormat);
+				          << "\n    ColourFormat: " << WStringToString(colourFormat);
 			}
 			return logStream.str();
 		});

--- a/ZakoVDD/Config/DriverSettings.cpp
+++ b/ZakoVDD/Config/DriverSettings.cpp
@@ -103,9 +103,15 @@ void LoadDriverSettings()
 	// colour
 	HDRPlus = EnabledQuery(L"HDRPlusEnabled");
 	SDR10 = EnabledQuery(L"SDR10Enabled");
-	HDRCOLOUR = HDRPlus ? IDDCX_BITS_PER_COMPONENT_12 : IDDCX_BITS_PER_COMPONENT_10;
-	SDRCOLOUR = SDR10 ? IDDCX_BITS_PER_COMPONENT_10 : IDDCX_BITS_PER_COMPONENT_8;
-	ColourFormat = GetStringSetting(L"ColourFormat");
+	const auto hdrColour = HDRPlus ? IDDCX_BITS_PER_COMPONENT_12 : IDDCX_BITS_PER_COMPONENT_10;
+	const auto sdrColour = SDR10 ? IDDCX_BITS_PER_COMPONENT_10 : IDDCX_BITS_PER_COMPONENT_8;
+	const auto colourFormat = GetStringSetting(L"ColourFormat");
+	{
+		lock_guard<mutex> dataLock(g_DataMutex);
+		HDRCOLOUR = hdrColour;
+		SDRCOLOUR = sdrColour;
+		ColourFormat = colourFormat;
+	}
 
 	// EDID profile: Auto -> resolved via host OS build number (issue #612).
 	ApplyEdidProfileSetting(GetStringSetting(L"EdidProfile"));

--- a/ZakoVDD/Control/ControlTransport.cpp
+++ b/ZakoVDD/Control/ControlTransport.cpp
@@ -110,6 +110,13 @@ static NTSTATUS HandleOpenFrameChannel(WDFDEVICE Device,
 	{
 		return STATUS_INVALID_PARAMETER;
 	}
+	const ULONG requestorProcessId = WdfRequestGetRequestorProcessId(Request);
+	if (requestorProcessId == 0 || request.TargetProcessId != requestorProcessId)
+	{
+		VDD_LOG_WARNING_STREAM("[IOCTL] Rejected frame channel target pid="
+		                       << request.TargetProcessId << " for requestor pid=" << requestorProcessId);
+		return STATUS_ACCESS_DENIED;
+	}
 
 	auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
 	if (!pContext || !pContext->pContext)
@@ -321,8 +328,8 @@ DWORD WINAPI NamedPipeServer(LPVOID lpParam)
 	{
 		hPipe = CreateNamedPipeW(
 			PIPE_NAME,
-			PIPE_ACCESS_DUPLEX,
-			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+			PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
 			PIPE_UNLIMITED_INSTANCES,
 			512, 512,
 			0,
@@ -385,7 +392,7 @@ void StopNamedPipeServer()
 			0,
 			NULL,
 			OPEN_EXISTING,
-			0,
+			SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
 			NULL);
 
 		if (hPipe != INVALID_HANDLE_VALUE)

--- a/ZakoVDD/Core/DriverState.cpp
+++ b/ZakoVDD/Core/DriverState.cpp
@@ -1,12 +1,11 @@
 #include "DriverState.h"
 
 std::mutex g_Mutex;
-std::mutex g_DataMutex; // Protects monitorModes, s_KnownMonitorModes2, numVirtualDisplays, gpuname
+std::mutex g_DataMutex; // Protects monitorModes, display colour settings, numVirtualDisplays, gpuname
 WDFDEVICE g_GlobalDevice = nullptr;
 
 DriverOptions Options;
 std::vector<std::tuple<int, int, int, int>> monitorModes;
-std::vector<DISPLAYCONFIG_VIDEO_SIGNAL_INFO> s_KnownMonitorModes2;
 UINT numVirtualDisplays = 1;
 std::wstring gpuname = L"";
 std::wstring confpath = []()

--- a/ZakoVDD/Core/DriverState.h
+++ b/ZakoVDD/Core/DriverState.h
@@ -15,7 +15,6 @@ extern WDFDEVICE g_GlobalDevice;
 
 extern DriverOptions Options;
 extern std::vector<std::tuple<int, int, int, int>> monitorModes;
-extern std::vector<DISPLAYCONFIG_VIDEO_SIGNAL_INFO> s_KnownMonitorModes2;
 extern UINT numVirtualDisplays;
 extern std::wstring gpuname;
 extern std::wstring confpath;

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -22,6 +22,12 @@ void CreateTargetMode2(IDDCX_TARGET_MODE2 &Mode, UINT Width, UINT Height, UINT V
 void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClientGuid, float maxNits, float minNits, float maxFALL, float widthCm, float heightCm)
 {
 	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+	auto existingMonitor = m_Monitors.find(index);
+	if (existingMonitor != m_Monitors.end() && existingMonitor->second != nullptr)
+	{
+		VDD_LOG_INFO_STREAM("Monitor " << (index + 1) << " already exists; treating duplicate create as success");
+		return;
+	}
 
 	wstring logMessage = L"Creating Monitor: " + to_wstring(index + 1);
 	string narrowLogMessage = WStringToString(logMessage);
@@ -125,15 +131,6 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		pMonitorEdid = &s_KnownMonitorEdid;
 	}
 
-	if (pClientGuid != nullptr)
-	{
-		m_MonitorGuids[index] = *pClientGuid;
-	}
-	else
-	{
-		m_MonitorGuids.erase(index);
-	}
-
 	IDDCX_MONITOR_INFO MonitorInfo = {};
 	MonitorInfo.Size = sizeof(MonitorInfo);
 	MonitorInfo.MonitorType = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI;
@@ -178,22 +175,6 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 			return;
 		}
 
-		m_Monitors[index] = newMonitor;
-
-		{
-			lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
-			MonitorHdrSettings hdrSettings;
-			hdrSettings.maxNits = maxNits;
-			hdrSettings.minNits = minNits;
-			hdrSettings.maxFALL = maxFALL;
-			s_MonitorHdrSettingsMap[newMonitor] = hdrSettings;
-
-			VDD_LOG_DEBUG_STREAM("Stored HDR luminance settings for monitor " << (index + 1)
-			                     << " - MaxNits: " << maxNits
-			                     << ", MinNits: " << minNits
-			                     << ", MaxFALL: " << maxFALL);
-		}
-
 		auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(MonitorCreateOut.MonitorObject);
 		pContext->pContext = this;
 
@@ -201,11 +182,31 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		Status = IddCxMonitorArrival(newMonitor, &ArrivalOut);
 		if (NT_SUCCESS(Status))
 		{
+			m_Monitors[index] = newMonitor;
+			if (pClientGuid != nullptr)
+			{
+				m_MonitorGuids[index] = *pClientGuid;
+			}
+			else
+			{
+				m_MonitorGuids.erase(index);
+			}
+
+			{
+				lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
+				MonitorHdrSettings hdrSettings;
+				hdrSettings.maxNits = maxNits;
+				hdrSettings.minNits = minNits;
+				hdrSettings.maxFALL = maxFALL;
+				s_MonitorHdrSettingsMap[newMonitor] = hdrSettings;
+			}
+
 			VDD_LOG_DEBUG("Monitor arrival successfully reported.");
 		}
 		else
 		{
 			VDD_LOG_ERROR_STREAM("Failed to report monitor arrival. Status: " << Status);
+			WdfObjectDelete(newMonitor);
 		}
 	}
 	else
@@ -366,15 +367,6 @@ int IndirectDeviceContext::RefreshMonitorModes()
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
 		localModes = monitorModes;
-		s_KnownMonitorModes2.clear();
-		for (size_t i = 0; i < localModes.size(); ++i)
-		{
-			s_KnownMonitorModes2.push_back(dispinfo(
-				get<0>(localModes[i]),
-				get<1>(localModes[i]),
-				get<2>(localModes[i]),
-				get<3>(localModes[i])));
-		}
 	}
 
 	if (localModes.empty())

--- a/ZakoVDD/Edid/Edid.cpp
+++ b/ZakoVDD/Edid/Edid.cpp
@@ -329,9 +329,11 @@ static vector<BYTE> LoadEdid(const string &filePath)
 	streamsize size = file.tellg();
 	file.seekg(0, ios::beg);
 
-	if (size <= 0 || size > 1024 * 1024)
+	constexpr streamsize edidBlockSize = 128;
+	constexpr streamsize maxEdidSize = edidBlockSize * 256;
+	if (size < edidBlockSize || size > maxEdidSize || (size % edidBlockSize) != 0)
 	{
-		VDD_LOG_ERROR("Custom edid file size invalid (must be >0 and <=1MB)");
+		VDD_LOG_ERROR("Custom edid file size invalid (must be 1-256 complete 128-byte blocks)");
 		VDD_LOG_INFO("Using hardcoded edid");
 		return hardcodedEdid;
 	}
@@ -339,12 +341,28 @@ static vector<BYTE> LoadEdid(const string &filePath)
 	vector<BYTE> buffer(static_cast<size_t>(size));
 	if (file.read(reinterpret_cast<char *>(buffer.data()), size))
 	{
-		BYTE calculatedChecksum = CalculateEdidChecksum(buffer);
-		if (calculatedChecksum != buffer[127])
+		const size_t blockCount = buffer.size() / static_cast<size_t>(edidBlockSize);
+		if (buffer[126] != blockCount - 1)
 		{
-			VDD_LOG_ERROR("Custom edid failed due to invalid checksum");
+			VDD_LOG_ERROR("Custom edid extension count does not match file size");
 			VDD_LOG_INFO("Using hardcoded edid");
 			return hardcodedEdid;
+		}
+
+		for (size_t block = 0; block < blockCount; ++block)
+		{
+			unsigned int checksum = 0;
+			const size_t blockOffset = block * static_cast<size_t>(edidBlockSize);
+			for (size_t i = 0; i < static_cast<size_t>(edidBlockSize); ++i)
+			{
+				checksum += buffer[blockOffset + i];
+			}
+			if ((checksum & 0xFFu) != 0)
+			{
+				VDD_LOG_ERROR_STREAM("Custom edid block " << block << " failed checksum validation");
+				VDD_LOG_INFO("Using hardcoded edid");
+				return hardcodedEdid;
+			}
 		}
 
 		if (edidCeaOverride)

--- a/ZakoVDD/Rendering/SharedFrameExporter.cpp
+++ b/ZakoVDD/Rendering/SharedFrameExporter.cpp
@@ -722,7 +722,7 @@ bool SharedFrameExporter::EnsureSharedTexture(const D3D11_TEXTURE2D_DESC& srcDes
 	SECURITY_ATTRIBUTES sa = {};
 	PSECURITY_DESCRIPTOR sd = nullptr;
 	if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
-	        L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)", SDDL_REVISION_1, &sd, nullptr))
+	        L"D:(A;;GA;;;SY)(A;;GA;;;BA)", SDDL_REVISION_1, &sd, nullptr))
 	{
 		VDD_LOG_ERROR("[VddExport] Failed to build SDDL for shared texture");
 		return false;
@@ -833,7 +833,7 @@ bool SharedFrameExporter::EnsureEventAndMetadata(const D3D11_TEXTURE2D_DESC& src
 	SECURITY_ATTRIBUTES sa = {};
 	PSECURITY_DESCRIPTOR sd = nullptr;
 	if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
-	        L"D:(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)", SDDL_REVISION_1, &sd, nullptr))
+	        L"D:(A;;GA;;;SY)(A;;GA;;;BA)", SDDL_REVISION_1, &sd, nullptr))
 	{
 		return false;
 	}

--- a/ZakoVDD/ZakoVDD.inf
+++ b/ZakoVDD/ZakoVDD.inf
@@ -37,7 +37,7 @@ HKR,, "UpperFilters",  %REG_MULTI_SZ%, "IndirectKmd"
 HKR, "WUDF", "DeviceGroupId", %REG_SZ%, "ZakoVDDGroup"
 
 [MyDevice_DeviceSecurity]
-HKR,, "Security", %REG_SZ%, "D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GRGW;;;IU)"
+HKR,, "Security", %REG_SZ%, "D:P(A;;GA;;;SY)(A;;GA;;;BA)"
 
 [MyDevice_Install.NT.Services]
 AddService=WUDFRd,0x000001fa,WUDFRD_ServiceInstall


### PR DESCRIPTION
## 改了啥呀

- 把控制设备、兼容管道和帧通道对象收紧到 SYSTEM/管理员，并为管道启用 first-instance 与拒绝远程客户端
- 帧通道 IOCTL 只允许把句柄复制给真正的请求进程，堵住任意目标 PID 的跨进程句柄注入
- 补齐 EDID 长度、校验和、扩展块及显示时序边界检查
- 用一致快照读取模式/颜色配置，修正并发更新竞态
- 简化显示器创建/删除状态机，补齐失败回滚与重复调用幂等性
- 配套接入 [Foundation#817](https://github.com/AlkaidLab/foundation-sunshine/pull/817) 和 [sunshine-control-panel#58](https://github.com/qiin2333/sunshine-control-panel/pull/58)

## 为啥要改

这些路径跨越普通用户、管理员、LocalSystem 和 Sunshine 进程边界。原实现里真正需要修的是对象 ACL、旧管道冒充、目标 PID 信任、输入校验和状态竞态；证书问题不在本 PR 范围。把边界收紧以后，普通用户不能直接驱动控制或拿帧句柄，合法的 Foundation/UAC 路径仍然能工作，杂鱼绕路就到此为止啦。

## 验证

- 最新 `main` 上运行 `tools\\vdd_capture_test\\build_vdd.bat`：Release、代码分析、签名检查、catalog 生成全部通过
- 本机安装为 `oem144.inf`，适配器和显示器均为 `CM_PROB_NONE`
- 普通用户访问控制接口被拒；管理员创建、重复创建和重载命令均成功
- 按要求重复触发 UAC 重载，重载前后帧序号持续前进（82→91、234→252）
- 密封帧通道能力为 `flags=0x7`、3 slots、128-byte metadata；重载前后 3 个 slot 均可打开，`dropped_held=0`、`dropped_acquire=0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitor creation behavior for duplicate requests and ensured failed monitor arrivals are properly cleaned up.
  * Improved reliability and thread-safety of monitor mode and color handling by using per-call snapshots.
  * Added stricter custom EDID validation (full 128-byte blocks with per-block checksums) with safe fallback to the built-in EDID.
* **Security**
  * Enforced that frame-channel IOCTL requests can only target the calling process.
  * Tightened shared resource and device security to SYSTEM and Administrators only; improved named-pipe startup/shutdown security handling.
* **Documentation**
  * Clarified IOCTL comment wording regarding valid duplicated frame-channel handle values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->