### PR TITLE
fix(modes): re-enumerate monitors when descriptions change

### DIFF
--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -539,10 +539,13 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 	bool modeListChanged = false;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
+		// Mode order is significant because the parse callbacks report index 0
+		// as the preferred monitor mode.
 		modeListChanged = monitorModes != parsed;
 		monitorModes = parsed;
 	}
-	VDD_LOG_INFO_STREAM("SETMODES: applied " << parsed.size() << " modes (in-memory only)");
+	VDD_LOG_INFO_STREAM("SETMODES: staged " << parsed.size()
+	                    << " modes (modeListChanged=" << (modeListChanged ? "true" : "false") << ")");
 
 	if (g_GlobalDevice != nullptr)
 	{

--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -491,7 +491,9 @@ void HandleRefreshModesCommand(HANDLE, wchar_t *)
 		return;
 	}
 
-	int n = pContext->pContext->RefreshMonitorModes();
+	// REFRESHMODES is the explicit force-republish command for mode lists that
+	// may have been changed outside SETMODES.
+	int n = pContext->pContext->RefreshMonitorModes(true);
 	VDD_LOG_INFO_STREAM("REFRESHMODES: published modes to " << n << " monitor(s)");
 }
 
@@ -531,12 +533,13 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 		return;
 	}
 
-	// Keep the in-memory list and any live monitor publication atomic with
-	// respect to create/destroy commands. This also ensures a monitor arrival
-	// and its recorded description snapshot observe the same mode generation.
+	// Compare, replace and publish the list atomically with respect to
+	// create/destroy commands.
 	lock_guard<mutex> lock(g_Mutex);
+	bool modeListChanged = false;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
+		modeListChanged = monitorModes != parsed;
 		monitorModes = parsed;
 	}
 	VDD_LOG_INFO_STREAM("SETMODES: applied " << parsed.size() << " modes (in-memory only)");
@@ -546,7 +549,7 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 		auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
 		if (pContext && pContext->pContext)
 		{
-			int n = pContext->pContext->RefreshMonitorModes();
+			int n = pContext->pContext->RefreshMonitorModes(modeListChanged);
 			VDD_LOG_INFO_STREAM("SETMODES: published to " << n << " live monitor(s)");
 		}
 	}

--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -492,7 +492,7 @@ void HandleRefreshModesCommand(HANDLE, wchar_t *)
 	}
 
 	int n = pContext->pContext->RefreshMonitorModes();
-	VDD_LOG_INFO_STREAM("REFRESHMODES: refreshed " << n << " monitor(s) without departure");
+	VDD_LOG_INFO_STREAM("REFRESHMODES: published modes to " << n << " monitor(s)");
 }
 
 void HandleSetModesCommand(HANDLE, wchar_t *param)
@@ -531,6 +531,10 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 		return;
 	}
 
+	// Keep the in-memory list and any live monitor publication atomic with
+	// respect to create/destroy commands. This also ensures a monitor arrival
+	// and its recorded description snapshot observe the same mode generation.
+	lock_guard<mutex> lock(g_Mutex);
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
 		monitorModes = parsed;
@@ -539,12 +543,11 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 
 	if (g_GlobalDevice != nullptr)
 	{
-		lock_guard<mutex> lock(g_Mutex);
 		auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
 		if (pContext && pContext->pContext)
 		{
 			int n = pContext->pContext->RefreshMonitorModes();
-			VDD_LOG_INFO_STREAM("SETMODES: pushed to " << n << " live monitor(s)");
+			VDD_LOG_INFO_STREAM("SETMODES: published to " << n << " live monitor(s)");
 		}
 	}
 }

--- a/ZakoVDD/Device/IndirectDeviceContext.h
+++ b/ZakoVDD/Device/IndirectDeviceContext.h
@@ -6,7 +6,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <tuple>
 #include <vector>
 
 namespace Microsoft
@@ -40,7 +39,7 @@ namespace Microsoft
 			void UnassignAllSwapChains();
 			void DestroyAllMonitors();
 
-			int RefreshMonitorModes();
+			int RefreshMonitorModes(bool refreshMonitorDescription);
 
 		protected:
 			struct MonitorCreationParams
@@ -62,10 +61,6 @@ namespace Microsoft
 			std::map<unsigned int, IDDCX_MONITOR> m_Monitors;
 			std::map<unsigned int, GUID> m_MonitorGuids;
 			std::map<unsigned int, MonitorCreationParams> m_MonitorCreationParams;
-			// IddCxMonitorUpdateModes2 updates target modes only. Keep the
-			// monitor-description snapshot from arrival so mode-list changes
-			// can trigger a new arrival and force Windows to reparse it.
-			std::map<unsigned int, std::vector<std::tuple<int, int, int, int>>> m_MonitorDescriptionModes;
 
 			std::map<IDDCX_MONITOR, DISPLAYCONFIG_VIDEO_SIGNAL_INFO> m_CommittedTargetModes;
 			// Presence in this map means CommitModes2 supplied an authoritative

--- a/ZakoVDD/Device/IndirectDeviceContext.h
+++ b/ZakoVDD/Device/IndirectDeviceContext.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <tuple>
 #include <vector>
 
 namespace Microsoft
@@ -42,11 +43,29 @@ namespace Microsoft
 			int RefreshMonitorModes();
 
 		protected:
+			struct MonitorCreationParams
+			{
+				bool hasClientGuid = false;
+				GUID clientGuid{};
+				float maxNits = 1000.0f;
+				float minNits = 0.0001f;
+				float maxFALL = 0.0f;
+				float widthCm = 0.0f;
+				float heightCm = 0.0f;
+			};
+
+			bool RecreateMonitor(unsigned int index);
+
 			WDFDEVICE m_WdfDevice;
 			IDDCX_ADAPTER m_Adapter;
 			mutable std::recursive_mutex m_monitorsMutex;
 			std::map<unsigned int, IDDCX_MONITOR> m_Monitors;
 			std::map<unsigned int, GUID> m_MonitorGuids;
+			std::map<unsigned int, MonitorCreationParams> m_MonitorCreationParams;
+			// IddCxMonitorUpdateModes2 updates target modes only. Keep the
+			// monitor-description snapshot from arrival so mode-list changes
+			// can trigger a new arrival and force Windows to reparse it.
+			std::map<unsigned int, std::vector<std::tuple<int, int, int, int>>> m_MonitorDescriptionModes;
 
 			std::map<IDDCX_MONITOR, DISPLAYCONFIG_VIDEO_SIGNAL_INFO> m_CommittedTargetModes;
 			// Presence in this map means CommitModes2 supplied an authoritative

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -397,6 +397,9 @@ bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
 	const bool recreated = m_Monitors.count(index) > 0;
 	if (!recreated)
 	{
+		// Preserve the parameters so a later forced refresh can retry this
+		// monitor instead of losing its configuration permanently.
+		m_MonitorCreationParams[index] = params;
 		VDD_LOG_ERROR_STREAM("RecreateMonitor: failed to re-enumerate monitor index=" << index);
 	}
 	return recreated;
@@ -421,8 +424,8 @@ int IndirectDeviceContext::RefreshMonitorModes(bool refreshMonitorDescription)
 	if (refreshMonitorDescription)
 	{
 		vector<unsigned int> monitorIndices;
-		monitorIndices.reserve(m_Monitors.size());
-		for (const auto &pair : m_Monitors)
+		monitorIndices.reserve(m_MonitorCreationParams.size());
+		for (const auto &pair : m_MonitorCreationParams)
 		{
 			monitorIndices.push_back(pair.first);
 		}

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -49,10 +49,12 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 
 	BYTE freeSyncMinHz = 48;
 	BYTE freeSyncMaxHz = 60;
+	vector<tuple<int, int, int, int>> descriptionModes;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
+		descriptionModes = monitorModes;
 		float maxHz = 0.0f;
-		for (const auto &m : monitorModes)
+		for (const auto &m : descriptionModes)
 		{
 			int num = get<2>(m);
 			int den = get<3>(m);
@@ -192,6 +194,20 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 				m_MonitorGuids.erase(index);
 			}
 
+			MonitorCreationParams creationParams;
+			if (pClientGuid != nullptr)
+			{
+				creationParams.hasClientGuid = true;
+				creationParams.clientGuid = *pClientGuid;
+			}
+			creationParams.maxNits = maxNits;
+			creationParams.minNits = minNits;
+			creationParams.maxFALL = maxFALL;
+			creationParams.widthCm = widthCm;
+			creationParams.heightCm = heightCm;
+			m_MonitorCreationParams[index] = creationParams;
+			m_MonitorDescriptionModes[index] = descriptionModes;
+
 			{
 				lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
 				MonitorHdrSettings hdrSettings;
@@ -223,6 +239,8 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 	if (monIt == m_Monitors.end() || monIt->second == nullptr)
 	{
 		VDD_LOG_WARNING_STREAM("Monitor handle for index " << index << " is already null or not found");
+		m_MonitorCreationParams.erase(index);
+		m_MonitorDescriptionModes.erase(index);
 		return;
 	}
 
@@ -319,6 +337,8 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 		VDD_LOG_DEBUG("Deleting monitor WDF object");
 		WdfObjectDelete(hMonitor);
 		m_Monitors.erase(monIt);
+		m_MonitorCreationParams.erase(index);
+		m_MonitorDescriptionModes.erase(index);
 		VDD_LOG_DEBUG("Monitor WDF object deleted successfully");
 
 		VDD_LOG_INFO_STREAM("Monitor object destroyed successfully (Index: " << index << ")");
@@ -327,11 +347,15 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 	{
 		VDD_LOG_ERROR_STREAM("Exception during monitor destruction (Index: " << index << "): " << e.what());
 		m_Monitors.erase(index);
+		m_MonitorCreationParams.erase(index);
+		m_MonitorDescriptionModes.erase(index);
 	}
 	catch (...)
 	{
 		VDD_LOG_ERROR("Unknown exception during monitor destruction");
 		m_Monitors.erase(index);
+		m_MonitorCreationParams.erase(index);
+		m_MonitorDescriptionModes.erase(index);
 	}
 }
 
@@ -355,14 +379,43 @@ void IndirectDeviceContext::DestroyAllMonitors()
 	}
 }
 
-int IndirectDeviceContext::RefreshMonitorModes()
+bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
 {
-	if (!IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2))
+	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+
+	auto paramsIt = m_MonitorCreationParams.find(index);
+	if (paramsIt == m_MonitorCreationParams.end())
 	{
-		VDD_LOG_WARNING("RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS");
-		return -1;
+		VDD_LOG_ERROR_STREAM("RecreateMonitor: creation parameters missing for monitor index=" << index);
+		return false;
 	}
 
+	const MonitorCreationParams params = paramsIt->second;
+	VDD_LOG_INFO_STREAM("RecreateMonitor: re-enumerating monitor index=" << index
+	                    << " so Windows reparses its monitor description");
+
+	DestroyMonitor(index);
+	Sleep(100);
+
+	const GUID *pClientGuid = params.hasClientGuid ? &params.clientGuid : nullptr;
+	CreateMonitor(index,
+	              pClientGuid,
+	              params.maxNits,
+	              params.minNits,
+	              params.maxFALL,
+	              params.widthCm,
+	              params.heightCm);
+
+	const bool recreated = m_Monitors.count(index) > 0;
+	if (!recreated)
+	{
+		VDD_LOG_ERROR_STREAM("RecreateMonitor: failed to re-enumerate monitor index=" << index);
+	}
+	return recreated;
+}
+
+int IndirectDeviceContext::RefreshMonitorModes()
+{
 	vector<tuple<int, int, int, int>> localModes;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
@@ -386,12 +439,35 @@ int IndirectDeviceContext::RefreshMonitorModes()
 	}
 
 	int refreshed = 0;
+	int targetModeUpdates = 0;
+	int recreatedMonitors = 0;
+	int failedMonitors = 0;
+	vector<unsigned int> monitorsToRecreate;
+	const bool canUpdateTargetModes = IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2);
 	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
 	for (const auto &pair : m_Monitors)
 	{
 		IDDCX_MONITOR hMonitor = pair.second;
 		if (hMonitor == nullptr)
 		{
+			continue;
+		}
+
+		auto descriptionModesIt = m_MonitorDescriptionModes.find(pair.first);
+		// Updating target modes cannot add a mode that is absent from the
+		// monitor-description list cached by Windows. Re-enumerate only when
+		// that description changed; unchanged lists retain the fast path.
+		if (descriptionModesIt == m_MonitorDescriptionModes.end() || descriptionModesIt->second != localModes)
+		{
+			monitorsToRecreate.push_back(pair.first);
+			continue;
+		}
+
+		if (!canUpdateTargetModes)
+		{
+			++failedMonitors;
+			VDD_LOG_WARNING_STREAM("RefreshMonitorModes: IddCxMonitorUpdateModes2 is unavailable for monitor index="
+			                       << pair.first);
 			continue;
 		}
 
@@ -404,17 +480,35 @@ int IndirectDeviceContext::RefreshMonitorModes()
 		if (NT_SUCCESS(status))
 		{
 			++refreshed;
+			++targetModeUpdates;
 			VDD_LOG_DEBUG_STREAM("RefreshMonitorModes: monitor index=" << pair.first
 			                     << " status=0x" << hex << status << " modeCount=" << dec << targetModes.size());
 		}
 		else
 		{
+			++failedMonitors;
 			VDD_LOG_WARNING_STREAM("RefreshMonitorModes: monitor index=" << pair.first
 			                       << " status=0x" << hex << status << " modeCount=" << dec << targetModes.size());
 		}
 	}
 
-	VDD_LOG_INFO_STREAM("RefreshMonitorModes: pushed " << refreshed << "/" << m_Monitors.size()
-	                    << " monitors with " << targetModes.size() << " modes (no departure)");
+	for (unsigned int index : monitorsToRecreate)
+	{
+		if (RecreateMonitor(index))
+		{
+			++refreshed;
+			++recreatedMonitors;
+		}
+		else
+		{
+			++failedMonitors;
+		}
+	}
+
+	VDD_LOG_INFO_STREAM("RefreshMonitorModes: published " << refreshed << "/"
+	                    << (refreshed + failedMonitors) << " monitor(s) with " << targetModes.size()
+	                    << " modes (target updates=" << targetModeUpdates
+	                    << ", re-enumerations=" << recreatedMonitors
+	                    << ", failures=" << failedMonitors << ")");
 	return refreshed;
 }

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -49,12 +49,10 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 
 	BYTE freeSyncMinHz = 48;
 	BYTE freeSyncMaxHz = 60;
-	vector<tuple<int, int, int, int>> descriptionModes;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
-		descriptionModes = monitorModes;
 		float maxHz = 0.0f;
-		for (const auto &m : descriptionModes)
+		for (const auto &m : monitorModes)
 		{
 			int num = get<2>(m);
 			int den = get<3>(m);
@@ -194,19 +192,14 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 				m_MonitorGuids.erase(index);
 			}
 
-			MonitorCreationParams creationParams;
-			if (pClientGuid != nullptr)
-			{
-				creationParams.hasClientGuid = true;
-				creationParams.clientGuid = *pClientGuid;
-			}
-			creationParams.maxNits = maxNits;
-			creationParams.minNits = minNits;
-			creationParams.maxFALL = maxFALL;
-			creationParams.widthCm = widthCm;
-			creationParams.heightCm = heightCm;
-			m_MonitorCreationParams[index] = creationParams;
-			m_MonitorDescriptionModes[index] = descriptionModes;
+			m_MonitorCreationParams[index] = {
+				pClientGuid != nullptr,
+				pClientGuid != nullptr ? *pClientGuid : GUID{},
+				maxNits,
+				minNits,
+				maxFALL,
+				widthCm,
+				heightCm};
 
 			{
 				lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
@@ -240,7 +233,6 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 	{
 		VDD_LOG_WARNING_STREAM("Monitor handle for index " << index << " is already null or not found");
 		m_MonitorCreationParams.erase(index);
-		m_MonitorDescriptionModes.erase(index);
 		return;
 	}
 
@@ -337,8 +329,6 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 		VDD_LOG_DEBUG("Deleting monitor WDF object");
 		WdfObjectDelete(hMonitor);
 		m_Monitors.erase(monIt);
-		m_MonitorCreationParams.erase(index);
-		m_MonitorDescriptionModes.erase(index);
 		VDD_LOG_DEBUG("Monitor WDF object deleted successfully");
 
 		VDD_LOG_INFO_STREAM("Monitor object destroyed successfully (Index: " << index << ")");
@@ -347,16 +337,14 @@ void IndirectDeviceContext::DestroyMonitor(unsigned int index)
 	{
 		VDD_LOG_ERROR_STREAM("Exception during monitor destruction (Index: " << index << "): " << e.what());
 		m_Monitors.erase(index);
-		m_MonitorCreationParams.erase(index);
-		m_MonitorDescriptionModes.erase(index);
 	}
 	catch (...)
 	{
 		VDD_LOG_ERROR("Unknown exception during monitor destruction");
 		m_Monitors.erase(index);
-		m_MonitorCreationParams.erase(index);
-		m_MonitorDescriptionModes.erase(index);
 	}
+
+	m_MonitorCreationParams.erase(index);
 }
 
 void IndirectDeviceContext::DestroyAllMonitors()
@@ -414,7 +402,7 @@ bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
 	return recreated;
 }
 
-int IndirectDeviceContext::RefreshMonitorModes()
+int IndirectDeviceContext::RefreshMonitorModes(bool refreshMonitorDescription)
 {
 	vector<tuple<int, int, int, int>> localModes;
 	{
@@ -428,6 +416,40 @@ int IndirectDeviceContext::RefreshMonitorModes()
 		return 0;
 	}
 
+	int refreshed = 0;
+	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+	if (refreshMonitorDescription)
+	{
+		vector<unsigned int> monitorIndices;
+		monitorIndices.reserve(m_Monitors.size());
+		for (const auto &pair : m_Monitors)
+		{
+			monitorIndices.push_back(pair.first);
+		}
+
+		// Updating target modes cannot add a mode that is absent from the
+		// monitor-description list cached by Windows. Callers request this
+		// path only when that description must be republished.
+		for (unsigned int index : monitorIndices)
+		{
+			if (RecreateMonitor(index))
+			{
+				++refreshed;
+			}
+		}
+
+		VDD_LOG_INFO_STREAM("RefreshMonitorModes: re-enumerated " << refreshed << "/"
+		                    << monitorIndices.size() << " monitor(s) with " << localModes.size()
+		                    << " updated monitor-description modes");
+		return refreshed;
+	}
+
+	if (!IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2))
+	{
+		VDD_LOG_WARNING("RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS");
+		return -1;
+	}
+
 	vector<IDDCX_TARGET_MODE2> targetModes(localModes.size());
 	for (size_t i = 0; i < localModes.size(); ++i)
 	{
@@ -438,36 +460,10 @@ int IndirectDeviceContext::RefreshMonitorModes()
 			static_cast<UINT>(get<3>(localModes[i])));
 	}
 
-	int refreshed = 0;
-	int targetModeUpdates = 0;
-	int recreatedMonitors = 0;
-	int failedMonitors = 0;
-	vector<unsigned int> monitorsToRecreate;
-	const bool canUpdateTargetModes = IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2);
-	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
 	for (const auto &pair : m_Monitors)
 	{
-		IDDCX_MONITOR hMonitor = pair.second;
-		if (hMonitor == nullptr)
+		if (pair.second == nullptr)
 		{
-			continue;
-		}
-
-		auto descriptionModesIt = m_MonitorDescriptionModes.find(pair.first);
-		// Updating target modes cannot add a mode that is absent from the
-		// monitor-description list cached by Windows. Re-enumerate only when
-		// that description changed; unchanged lists retain the fast path.
-		if (descriptionModesIt == m_MonitorDescriptionModes.end() || descriptionModesIt->second != localModes)
-		{
-			monitorsToRecreate.push_back(pair.first);
-			continue;
-		}
-
-		if (!canUpdateTargetModes)
-		{
-			++failedMonitors;
-			VDD_LOG_WARNING_STREAM("RefreshMonitorModes: IddCxMonitorUpdateModes2 is unavailable for monitor index="
-			                       << pair.first);
 			continue;
 		}
 
@@ -476,39 +472,21 @@ int IndirectDeviceContext::RefreshMonitorModes()
 		inArgs.TargetModeCount = static_cast<UINT>(targetModes.size());
 		inArgs.pTargetModes = targetModes.data();
 
-		NTSTATUS status = IddCxMonitorUpdateModes2(hMonitor, &inArgs);
+		NTSTATUS status = IddCxMonitorUpdateModes2(pair.second, &inArgs);
 		if (NT_SUCCESS(status))
 		{
 			++refreshed;
-			++targetModeUpdates;
 			VDD_LOG_DEBUG_STREAM("RefreshMonitorModes: monitor index=" << pair.first
 			                     << " status=0x" << hex << status << " modeCount=" << dec << targetModes.size());
 		}
 		else
 		{
-			++failedMonitors;
 			VDD_LOG_WARNING_STREAM("RefreshMonitorModes: monitor index=" << pair.first
 			                       << " status=0x" << hex << status << " modeCount=" << dec << targetModes.size());
 		}
 	}
 
-	for (unsigned int index : monitorsToRecreate)
-	{
-		if (RecreateMonitor(index))
-		{
-			++refreshed;
-			++recreatedMonitors;
-		}
-		else
-		{
-			++failedMonitors;
-		}
-	}
-
-	VDD_LOG_INFO_STREAM("RefreshMonitorModes: published " << refreshed << "/"
-	                    << (refreshed + failedMonitors) << " monitor(s) with " << targetModes.size()
-	                    << " modes (target updates=" << targetModeUpdates
-	                    << ", re-enumerations=" << recreatedMonitors
-	                    << ", failures=" << failedMonitors << ")");
+	VDD_LOG_INFO_STREAM("RefreshMonitorModes: updated target modes for " << refreshed << "/"
+	                    << m_Monitors.size() << " monitor(s) with " << targetModes.size() << " modes");
 	return refreshed;
 }


### PR DESCRIPTION
## 改了啥呀

- `SETMODES` 在覆盖全局列表前直接计算 `modeListChanged`，并将比较、写入和 live publication 串行化。
- 模式列表未变化时继续使用 `IddCxMonitorUpdateModes2` 快速刷新 target modes。
- 模式列表变化时受控重建 live monitors，让 Windows 重新解析 monitor-description modes。
- 只保存重建所需的创建参数，保留客户端 GUID、HDR 亮度和物理尺寸。
- `REFRESHMODES` 明确作为强制重新发布 monitor description 的命令。

## 为啥要改

`IddCxMonitorUpdateModes2` 的输入只有 target modes。这个杂鱼状态看起来刷新成功，Windows 却可能仍缓存旧的 monitor-description modes；2340×1080、3024×1964 等新动态分辨率不在最终交集里，因此不会被系统公布。

实现现在只有一个决策：

- 列表相同：原生 target-mode 快速路径，不发生 departure。
- 列表变化：一次受控 departure/arrival，可靠更新 monitor description。

没有 per-monitor 模式快照，没有额外协议状态，也没有重复重建循环。

## 用户影响

- 新动态分辨率可以在一次 `SETMODES` 内完成发布，不再要求调用方额外发送 `DESTROYMONITOR` / `CREATEMONITOR`。
- 相同 mode list 重新连接继续走快速路径。
- 现有命令协议保持兼容，无 ABI 变化。

## 验证

- `MSBuild ZakoVDD.sln /m /p:Configuration=Release /p:Platform=x64 /p:SkipPackageVerification=true`
  - C++ `/W4 /WX`
  - Driver code analysis
  - Link
  - ApiValidator
  - Inf2Cat
  - 结果：0 warnings, 0 errors
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 刷新显示模式时，可按需同时重新发布监视器信息，保证描述与当前配置一致。
  * 重建监视器时会保存并恢复创建参数（含 HDR/色温/亮度阈值与物理尺寸等），以维持显示一致性。
* **问题修复**
  * 改进模式更新时的比较与发布流程，降低因模式变更判定不一致导致的异常发布。
  * 优化无效监视器句柄跳过与发布同步逻辑，提升刷新稳定性，并更新相关日志口径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->