### PR TITLE
fix(vdd): remove hanging named pipe transport

### DIFF
--- a/Common/Include/vdd_control_ioctl.h
+++ b/Common/Include/vdd_control_ioctl.h
@@ -11,14 +11,11 @@
  * Transport summary:
  *   The driver exposes a custom WDF device interface
  *   (`GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`). Opening this interface with
- *   `CreateFileW` PnP-wakes the IddCx driver back into D0, eliminating the
- *   race that the old named pipe transport had with WUDFHost recycling.
+ *   `CreateFileW` PnP-wakes the IddCx driver back into D0 and remains valid
+ *   across WUDFHost recycling.
  *
- *   `IOCTL_VDD_COMMAND` carries the same NUL-terminated UTF-16 command
- *   buffer grammar as the legacy pipe protocol (e.g. `RELOAD_DRIVER`,
- *   `CREATEMONITOR ...`, `DESTROYMONITOR`). The in-driver dispatcher is
- *   shared verbatim between both transports, so callers do not need to
- *   re-encode anything when migrating from pipe to IOCTL.
+ *   `IOCTL_VDD_COMMAND` carries a NUL-terminated UTF-16 command buffer
+ *   (e.g. `RELOAD_DRIVER`, `CREATEMONITOR ...`, `DESTROYMONITOR`).
  *
  *   `IOCTL_VDD_PING` is a cheap liveness probe (no payload).
  *

--- a/ZakoVDD/Control/CommandDispatcher.cpp
+++ b/ZakoVDD/Control/CommandDispatcher.cpp
@@ -11,7 +11,7 @@ struct Command
 	VddCommandAction action;
 };
 
-void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
+void DispatchVddCommandBuffer(wchar_t *buffer)
 {
 	Command commands[] = {
 		{L"RELOAD_DRIVER", 13, HandleReloadDriverCommand},
@@ -29,8 +29,6 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 		{L"GETALLGPUS", 10, HandleGetAllGpusCommand},
 		{L"SETGPU", 6, HandleSetGpuCommand},
 		{L"SETDISPLAYCOUNT", 15, HandleSetDisplayCountCommand},
-		{L"GETSETTINGS", 11, HandleGetSettingsCommand},
-		{L"PING", 4, HandlePingCommand},
 		{L"REFRESHMODES", 12, HandleRefreshModesCommand},
 		{L"SETMODES", 8, HandleSetModesCommand},
 		{L"CREATEMONITOR", 13, HandleCreateMonitorCommand},
@@ -46,10 +44,10 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 			{
 				param++;
 			}
-			cmd.action(hPipeForResponse, param);
+			cmd.action(param);
 			return;
 		}
 	}
 
-	HandleUnknownCommand(hPipeForResponse, buffer);
+	HandleUnknownCommand(buffer);
 }

--- a/ZakoVDD/Control/CommandDispatcher.h
+++ b/ZakoVDD/Control/CommandDispatcher.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <windows.h>
+#include <wchar.h>
 
-void ReloadDriver(HANDLE hPipe);
-void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t* buffer);
+void ReloadDriver();
+void DispatchVddCommandBuffer(wchar_t *buffer);

--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -4,7 +4,6 @@
 #include "..\Adapter\GpuAdapterSelection.h"
 #include "..\Adapter\GpuStatus.h"
 #include "..\Config\DriverSettings.h"
-#include "..\Control\ControlTransport.h"
 #include "..\Device\IndirectDeviceContextWrapper.h"
 #include "..\Diagnostics\DriverDiagnostics.h"
 #include "..\Core\DriverState.h"
@@ -26,27 +25,25 @@ using namespace std;
 
 namespace
 {
-void ToggleSetting(HANDLE hPipe, wchar_t *param, const wchar_t *settingName, const char *enableMsg, const char *disableMsg)
+void ToggleSetting(wchar_t *param, const wchar_t *settingName, const char *enableMsg, const char *disableMsg)
 {
 	if (wcsncmp(param, L"true", 4) == 0)
 	{
 		UpdateXmlToggleSetting(true, settingName);
 		VDD_LOG_INFO(enableMsg);
-		ReloadDriver(hPipe);
+		ReloadDriver();
 	}
 	else if (wcsncmp(param, L"false", 5) == 0)
 	{
 		UpdateXmlToggleSetting(false, settingName);
 		VDD_LOG_INFO(disableMsg);
-		ReloadDriver(hPipe);
+		ReloadDriver();
 	}
 }
 }
 
-void ReloadDriver(HANDLE hPipe)
+void ReloadDriver()
 {
-	UNREFERENCED_PARAMETER(hPipe);
-
 	VDD_LOG_INFO("Starting driver reload process");
 
 	if (g_GlobalDevice == nullptr)
@@ -127,38 +124,38 @@ void ReloadDriver(HANDLE hPipe)
 	}
 }
 
-void HandleReloadDriverCommand(HANDLE hPipe, wchar_t *)
+void HandleReloadDriverCommand(wchar_t *)
 {
 	VDD_LOG_INFO("Reloading the driver");
-	ReloadDriver(hPipe);
+	ReloadDriver();
 }
 
-void HandleHdrPlusCommand(HANDLE hPipe, wchar_t *param)
+void HandleHdrPlusCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"HDRPlus", "HDR+ Enabled", "HDR+ Disabled");
+	ToggleSetting(param, L"HDRPlus", "HDR+ Enabled", "HDR+ Disabled");
 }
 
-void HandleSdr10Command(HANDLE hPipe, wchar_t *param)
+void HandleSdr10Command(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"SDR10bit", "SDR 10 Bit Enabled", "SDR 10 Bit Disabled");
+	ToggleSetting(param, L"SDR10bit", "SDR 10 Bit Enabled", "SDR 10 Bit Disabled");
 }
 
-void HandleCustomEdidCommand(HANDLE hPipe, wchar_t *param)
+void HandleCustomEdidCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"CustomEdid", "Custom Edid Enabled", "Custom Edid Disabled");
+	ToggleSetting(param, L"CustomEdid", "Custom Edid Enabled", "Custom Edid Disabled");
 }
 
-void HandlePreventSpoofCommand(HANDLE hPipe, wchar_t *param)
+void HandlePreventSpoofCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"PreventSpoof", "Prevent Spoof Enabled", "Prevent Spoof Disabled");
+	ToggleSetting(param, L"PreventSpoof", "Prevent Spoof Enabled", "Prevent Spoof Disabled");
 }
 
-void HandleCeaOverrideCommand(HANDLE hPipe, wchar_t *param)
+void HandleCeaOverrideCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"EdidCeaOverride", "Cea override Enabled", "Cea override Disabled");
+	ToggleSetting(param, L"EdidCeaOverride", "Cea override Enabled", "Cea override Disabled");
 }
 
-void HandleEdidProfileCommand(HANDLE, wchar_t *param)
+void HandleEdidProfileCommand(wchar_t *param)
 {
 	if (!param || *param == 0)
 	{
@@ -177,37 +174,37 @@ void HandleEdidProfileCommand(HANDLE, wchar_t *param)
 	VDD_LOG_INFO("EDID profile updated; recreate monitors to take effect");
 }
 
-void HandleVrrCommand(HANDLE hPipe, wchar_t *param)
+void HandleVrrCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"Vrr", "VRR Enabled", "VRR Disabled");
+	ToggleSetting(param, L"Vrr", "VRR Enabled", "VRR Disabled");
 }
 
-void HandleHardwareCursorCommand(HANDLE hPipe, wchar_t *param)
+void HandleHardwareCursorCommand(wchar_t *param)
 {
-	ToggleSetting(hPipe, param, L"HardwareCursor", "Hardware Cursor Enabled", "Hardware Cursor Disabled");
+	ToggleSetting(param, L"HardwareCursor", "Hardware Cursor Enabled", "Hardware Cursor Disabled");
 }
 
-void HandleD3DDeviceGpuCommand(HANDLE, wchar_t *)
+void HandleD3DDeviceGpuCommand(wchar_t *)
 {
 	VDD_LOG_INFO("Retrieving D3D GPU (This information may be inaccurate without reloading the driver first)");
 	InitializeD3DDeviceAndLogGPU();
 	VDD_LOG_INFO("Retrieved D3D GPU");
 }
 
-void HandleIddCxVersionCommand(HANDLE, wchar_t *)
+void HandleIddCxVersionCommand(wchar_t *)
 {
 	VDD_LOG_INFO("Logging iddcx version");
 	LogIddCxVersion();
 }
 
-void HandleGetAssignedGpuCommand(HANDLE, wchar_t *)
+void HandleGetAssignedGpuCommand(wchar_t *)
 {
 	VDD_LOG_INFO("Retrieving Assigned GPU");
 	GetGpuInfo();
 	VDD_LOG_INFO("Retrieved Assigned GPU");
 }
 
-void HandleGetAllGpusCommand(HANDLE, wchar_t *)
+void HandleGetAllGpusCommand(wchar_t *)
 {
 	VDD_LOG_INFO("Logging all GPUs");
 	VDD_LOG_INFO("Any GPUs which show twice but you only have one, will most likely be the GPU the driver is attached to");
@@ -215,7 +212,7 @@ void HandleGetAllGpusCommand(HANDLE, wchar_t *)
 	VDD_LOG_INFO("Logged all GPUs");
 }
 
-void HandleSetGpuCommand(HANDLE hPipe, wchar_t *param)
+void HandleSetGpuCommand(wchar_t *param)
 {
 	wstring gpuName = param;
 	gpuName = gpuName.substr(1, gpuName.size() - 2);
@@ -231,10 +228,10 @@ void HandleSetGpuCommand(HANDLE hPipe, wchar_t *param)
 	{
 		VDD_LOG_ERROR("Failed to update GPU setting in XML. Restarting anyway");
 	}
-	ReloadDriver(hPipe);
+	ReloadDriver();
 }
 
-void HandleSetDisplayCountCommand(HANDLE hPipe, wchar_t *param)
+void HandleSetDisplayCountCommand(wchar_t *param)
 {
 	VDD_LOG_INFO("Setting Display Count");
 
@@ -252,28 +249,10 @@ void HandleSetDisplayCountCommand(HANDLE hPipe, wchar_t *param)
 	{
 		VDD_LOG_ERROR("Failed to update display count setting in XML. Restarting anyway");
 	}
-	ReloadDriver(hPipe);
+	ReloadDriver();
 }
 
-void HandleGetSettingsCommand(HANDLE hPipe, wchar_t *)
-{
-	wstring settingsResponse = L"SETTINGS LOG=ETW";
-
-	if (hPipe != INVALID_HANDLE_VALUE && hPipe != NULL)
-	{
-		DWORD bytesWritten;
-		DWORD bytesToWrite = static_cast<DWORD>((settingsResponse.length() + 1) * sizeof(wchar_t));
-		WriteFile(hPipe, settingsResponse.c_str(), bytesToWrite, &bytesWritten, NULL);
-	}
-}
-
-void HandlePingCommand(HANDLE, wchar_t *)
-{
-	SendLegacyPipeMessage("PONG");
-	VDD_LOG_VERBOSE("Heartbeat Ping");
-}
-
-void HandleCreateMonitorCommand(HANDLE, wchar_t *param)
+void HandleCreateMonitorCommand(wchar_t *param)
 {
 	if (g_GlobalDevice == nullptr)
 	{
@@ -436,7 +415,7 @@ void HandleCreateMonitorCommand(HANDLE, wchar_t *param)
 	}
 }
 
-void HandleDestroyMonitorCommand(HANDLE, wchar_t *)
+void HandleDestroyMonitorCommand(wchar_t *)
 {
 	if (g_GlobalDevice == nullptr)
 	{
@@ -475,7 +454,7 @@ void HandleDestroyMonitorCommand(HANDLE, wchar_t *)
 	}
 }
 
-void HandleRefreshModesCommand(HANDLE, wchar_t *)
+void HandleRefreshModesCommand(wchar_t *)
 {
 	if (g_GlobalDevice == nullptr)
 	{
@@ -495,7 +474,7 @@ void HandleRefreshModesCommand(HANDLE, wchar_t *)
 	VDD_LOG_INFO_STREAM("REFRESHMODES: refreshed " << n << " monitor(s) without departure");
 }
 
-void HandleSetModesCommand(HANDLE, wchar_t *param)
+void HandleSetModesCommand(wchar_t *param)
 {
 	if (param == nullptr || *param == L'\0')
 	{
@@ -549,7 +528,7 @@ void HandleSetModesCommand(HANDLE, wchar_t *param)
 	}
 }
 
-void HandleUnknownCommand(HANDLE, wchar_t *buffer)
+void HandleUnknownCommand(wchar_t *buffer)
 {
 	VDD_LOG_ERROR("Unknown command");
 	VDD_LOG_ERROR(WStringToString(buffer).c_str());

--- a/ZakoVDD/Control/CommandHandlers.h
+++ b/ZakoVDD/Control/CommandHandlers.h
@@ -1,28 +1,26 @@
 #pragma once
 
-#include <windows.h>
+#include <wchar.h>
 
-using VddCommandAction = void (*)(HANDLE, wchar_t *);
+using VddCommandAction = void (*)(wchar_t *);
 
-void HandleReloadDriverCommand(HANDLE hPipe, wchar_t *param);
-void HandleHdrPlusCommand(HANDLE hPipe, wchar_t *param);
-void HandleSdr10Command(HANDLE hPipe, wchar_t *param);
-void HandleCustomEdidCommand(HANDLE hPipe, wchar_t *param);
-void HandlePreventSpoofCommand(HANDLE hPipe, wchar_t *param);
-void HandleCeaOverrideCommand(HANDLE hPipe, wchar_t *param);
-void HandleEdidProfileCommand(HANDLE hPipe, wchar_t *param);
-void HandleVrrCommand(HANDLE hPipe, wchar_t *param);
-void HandleHardwareCursorCommand(HANDLE hPipe, wchar_t *param);
-void HandleD3DDeviceGpuCommand(HANDLE hPipe, wchar_t *param);
-void HandleIddCxVersionCommand(HANDLE hPipe, wchar_t *param);
-void HandleGetAssignedGpuCommand(HANDLE hPipe, wchar_t *param);
-void HandleGetAllGpusCommand(HANDLE hPipe, wchar_t *param);
-void HandleSetGpuCommand(HANDLE hPipe, wchar_t *param);
-void HandleSetDisplayCountCommand(HANDLE hPipe, wchar_t *param);
-void HandleGetSettingsCommand(HANDLE hPipe, wchar_t *param);
-void HandlePingCommand(HANDLE hPipe, wchar_t *param);
-void HandleCreateMonitorCommand(HANDLE hPipe, wchar_t *param);
-void HandleDestroyMonitorCommand(HANDLE hPipe, wchar_t *param);
-void HandleRefreshModesCommand(HANDLE hPipe, wchar_t *param);
-void HandleSetModesCommand(HANDLE hPipe, wchar_t *param);
-void HandleUnknownCommand(HANDLE hPipe, wchar_t *buffer);
+void HandleReloadDriverCommand(wchar_t *param);
+void HandleHdrPlusCommand(wchar_t *param);
+void HandleSdr10Command(wchar_t *param);
+void HandleCustomEdidCommand(wchar_t *param);
+void HandlePreventSpoofCommand(wchar_t *param);
+void HandleCeaOverrideCommand(wchar_t *param);
+void HandleEdidProfileCommand(wchar_t *param);
+void HandleVrrCommand(wchar_t *param);
+void HandleHardwareCursorCommand(wchar_t *param);
+void HandleD3DDeviceGpuCommand(wchar_t *param);
+void HandleIddCxVersionCommand(wchar_t *param);
+void HandleGetAssignedGpuCommand(wchar_t *param);
+void HandleGetAllGpusCommand(wchar_t *param);
+void HandleSetGpuCommand(wchar_t *param);
+void HandleSetDisplayCountCommand(wchar_t *param);
+void HandleCreateMonitorCommand(wchar_t *param);
+void HandleDestroyMonitorCommand(wchar_t *param);
+void HandleRefreshModesCommand(wchar_t *param);
+void HandleSetModesCommand(wchar_t *param);
+void HandleUnknownCommand(wchar_t *buffer);

--- a/ZakoVDD/Control/ControlTransport.cpp
+++ b/ZakoVDD/Control/ControlTransport.cpp
@@ -5,23 +5,11 @@
 #include "..\Logging\Logger.h"
 #include "..\Util\StringConversion.h"
 
-#include <atomic>
-#include <cstring>
-#include <mutex>
-#include <sddl.h>
 #include <sstream>
 #include <string>
 #include <vdd_control_ioctl.h>
 
-#define PIPE_NAME L"\\\\.\\pipe\\ZakoVDDPipe"
-
 using namespace std;
-
-HANDLE hPipeThread = NULL;
-std::atomic<bool> g_Running{true};
-HANDLE g_pipeHandle = INVALID_HANDLE_VALUE;
-
-extern std::mutex g_Mutex;
 
 struct TargetProcessOpenContext
 {
@@ -155,40 +143,6 @@ static NTSTATUS HandleOpenFrameChannel(WDFDEVICE Device,
 	return STATUS_SUCCESS;
 }
 
-void SendLegacyPipeMessage(const char *message)
-{
-	if (message == nullptr || g_pipeHandle == INVALID_HANDLE_VALUE)
-	{
-		return;
-	}
-
-	DWORD bytesWritten = 0;
-	DWORD bytesToWrite = static_cast<DWORD>(strlen(message));
-	WriteFile(g_pipeHandle, message, bytesToWrite, &bytesWritten, NULL);
-}
-
-// [LEGACY-PIPE] entire function -- pipe-side wrapper around DispatchVddCommandBuffer
-void HandleClient(HANDLE hPipe)
-{
-	g_pipeHandle = hPipe;
-	VDD_LOG_VERBOSE("Client Handling Enabled");
-	wchar_t buffer[2048];
-	DWORD bytesRead;
-	BOOL result = ReadFile(hPipe, buffer, sizeof(buffer) - sizeof(wchar_t), &bytesRead, NULL);
-	if (result && bytesRead != 0)
-	{
-		buffer[bytesRead / sizeof(wchar_t)] = L'\0';
-		wstring bufferwstr(buffer);
-		string bufferstr = WStringToString(bufferwstr);
-		VDD_LOG_VERBOSE(bufferstr.c_str());
-
-		DispatchVddCommandBuffer(hPipe, buffer);
-	}
-	DisconnectNamedPipe(hPipe);
-	CloseHandle(hPipe);
-	g_pipeHandle = INVALID_HANDLE_VALUE;
-}
-
 // IddCx redirects every IRP_MJ_DEVICE_CONTROL into its own internal queue
 // before any default WDF queue ever sees it. The only way to receive a
 // custom IOCTL in an IddCx driver is through this callback registered via
@@ -245,8 +199,8 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			return;
 		}
 
-		// Mirror the legacy named-pipe HandleClient buffer (2048 wchar_t).
-		// Anything larger is almost certainly malformed input.
+		// Commands are deliberately capped at 2048 wchar_t. Anything larger
+		// is almost certainly malformed input.
 		if (InputBufferLength > 2048 * sizeof(wchar_t))
 		{
 			WdfRequestComplete(Request, STATUS_BUFFER_OVERFLOW);
@@ -280,10 +234,7 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			string bufferstr = WStringToString(bufferwstr);
 			VDD_LOG_VERBOSE(("[IOCTL] " + bufferstr).c_str());
 
-			// Pass INVALID_HANDLE_VALUE so response-emitting handlers
-			// (GETSETTINGS / PING) silently skip their WriteFile path.
-			// Sunshine never observes those responses anyway.
-			DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, buffer);
+			DispatchVddCommandBuffer(buffer);
 		}
 		catch (const std::exception &e)
 		{
@@ -301,110 +252,6 @@ VOID VirtualDisplayDriverIoDeviceControl(
 	default:
 		WdfRequestComplete(Request, STATUS_NOT_SUPPORTED);
 		return;
-	}
-}
-
-
-// [LEGACY-PIPE] entire function -- accept-loop thread for the named pipe
-DWORD WINAPI NamedPipeServer(LPVOID lpParam)
-{
-	UNREFERENCED_PARAMETER(lpParam);
-
-	SECURITY_ATTRIBUTES sa;
-	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
-	sa.bInheritHandle = FALSE;
-	const wchar_t *sddl = L"D:(A;;GA;;;SY)(A;;GA;;;BA)";
-	VDD_LOG_DEBUG("Starting pipe with parameters: D:(A;;GA;;;SY)(A;;GA;;;BA)");
-	if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
-			sddl, SDDL_REVISION_1, &sa.lpSecurityDescriptor, NULL))
-	{
-		DWORD ErrorCode = GetLastError();
-		string errorMsg = to_string(ErrorCode);
-		VDD_LOG_ERROR(errorMsg.c_str());
-		return 1;
-	}
-	HANDLE hPipe;
-	while (g_Running)
-	{
-		hPipe = CreateNamedPipeW(
-			PIPE_NAME,
-			PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
-			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-			PIPE_UNLIMITED_INSTANCES,
-			512, 512,
-			0,
-			&sa);
-
-		if (hPipe == INVALID_HANDLE_VALUE)
-		{
-			DWORD ErrorCode = GetLastError();
-			string errorMsg = to_string(ErrorCode);
-			VDD_LOG_ERROR(errorMsg.c_str());
-			LocalFree(sa.lpSecurityDescriptor);
-			return 1;
-		}
-
-		BOOL connected = ConnectNamedPipe(hPipe, NULL) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
-		if (connected)
-		{
-			VDD_LOG_VERBOSE("Client Connected");
-			HandleClient(hPipe);
-		}
-		else
-		{
-			CloseHandle(hPipe);
-		}
-	}
-	LocalFree(sa.lpSecurityDescriptor);
-	return 0;
-}
-
-// [LEGACY-PIPE] entire function
-void StartNamedPipeServer()
-{
-	VDD_LOG_VERBOSE("Starting Pipe");
-	hPipeThread = CreateThread(NULL, 0, NamedPipeServer, NULL, 0, NULL);
-	if (hPipeThread == NULL)
-	{
-		DWORD ErrorCode = GetLastError();
-		string errorMsg = to_string(ErrorCode);
-		VDD_LOG_ERROR(errorMsg.c_str());
-	}
-	else
-	{
-		VDD_LOG_VERBOSE("Pipe created");
-	}
-}
-
-// [LEGACY-PIPE] entire function
-void StopNamedPipeServer()
-{
-	VDD_LOG_VERBOSE("Stopping Pipe");
-	{
-		lock_guard<mutex> lock(g_Mutex);
-		g_Running = false;
-	}
-	if (hPipeThread)
-	{
-		HANDLE hPipe = CreateFileW(
-			PIPE_NAME,
-			GENERIC_READ | GENERIC_WRITE,
-			0,
-			NULL,
-			OPEN_EXISTING,
-			SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
-			NULL);
-
-		if (hPipe != INVALID_HANDLE_VALUE)
-		{
-			DisconnectNamedPipe(hPipe);
-			CloseHandle(hPipe);
-		}
-
-		WaitForSingleObject(hPipeThread, INFINITE);
-		CloseHandle(hPipeThread);
-		hPipeThread = NULL;
-		VDD_LOG_VERBOSE("Stopped Pipe");
 	}
 }
 

--- a/ZakoVDD/Control/ControlTransport.h
+++ b/ZakoVDD/Control/ControlTransport.h
@@ -3,7 +3,3 @@
 #include "..\Driver.h"
 
 EVT_IDD_CX_DEVICE_IO_CONTROL VirtualDisplayDriverIoDeviceControl;
-
-void StartNamedPipeServer();
-void StopNamedPipeServer();
-void SendLegacyPipeMessage(const char *message);

--- a/ZakoVDD/Device/IndirectDeviceContext.cpp
+++ b/ZakoVDD/Device/IndirectDeviceContext.cpp
@@ -2,7 +2,6 @@
 #include "..\Adapter\GpuAdapterSelection.h"
 #include "..\Adapter\GpuStatus.h"
 #include "..\Config\DriverSettings.h"
-#include "..\Control\ControlTransport.h"
 #include "..\Core\DriverState.h"
 #include "..\Edid\Edid.h"
 #include "..\Logging\Logger.h"
@@ -220,6 +219,5 @@ void IndirectDeviceContext::InitAdapter()
 void IndirectDeviceContext::FinishInit()
 {
 	Options.Adapter.apply(m_Adapter);
-	SendLegacyPipeMessage("FinishInit");
 	VDD_LOG_INFO("Applied Adapter configs.");
 }

--- a/ZakoVDD/Device/WdfDeviceLifecycle.cpp
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.cpp
@@ -73,9 +73,6 @@ VOID EvtDriverUnload(
 		Sleep(100);
 	}
 
-	// [LEGACY-PIPE] Stop the named pipe server
-	StopNamedPipeServer();
-
 	VDD_LOG_INFO("Driver unload completed");
 }
 
@@ -225,9 +222,7 @@ _Use_decl_annotations_
 	// Expose a custom device interface so external callers (Sunshine) can
 	// reach us via DeviceIoControl over CreateFile(\\?\GUID...). This is the
 	// transport that survives WUDFHost recycling: opening the interface
-	// PnP-wakes the driver back into D0 transparently. The legacy named pipe
-	// transport remains active in parallel for backwards compatibility but
-	// is now only the fallback path.
+	// PnP-wakes the driver back into D0 transparently.
 	Status = WdfDeviceCreateDeviceInterface(Device, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, NULL);
 	if (!NT_SUCCESS(Status))
 	{

--- a/ZakoVDD/Device/WdfDeviceLifecycle.cpp
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.cpp
@@ -226,14 +226,10 @@ _Use_decl_annotations_
 	Status = WdfDeviceCreateDeviceInterface(Device, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, NULL);
 	if (!NT_SUCCESS(Status))
 	{
-		VDD_LOG_ERROR_STREAM("WdfDeviceCreateDeviceInterface failed with status: " << Status
-		                     << " - IOCTL transport will be unavailable, pipe transport still works");
-		// Non-fatal: pipe transport remains usable, so don't abort device add.
+		VDD_LOG_ERROR_STREAM("WdfDeviceCreateDeviceInterface failed with status: " << Status);
+		return Status;
 	}
-	else
-	{
-		VDD_LOG_DEBUG("Registered Zako VDD control device interface");
-	}
+	VDD_LOG_DEBUG("Registered Zako VDD control device interface");
 
 	// Create a new device context object and attach it to the WDF device object
 	/*

--- a/ZakoVDD/Driver.cpp
+++ b/ZakoVDD/Driver.cpp
@@ -14,7 +14,6 @@ Environment:
 
 #include "Driver.h"
 #include "Config\DriverSettings.h"
-#include "Control\ControlTransport.h"
 #include "Core\DriverState.h"
 #include "Device\WdfDeviceLifecycle.h"
 #include "Diagnostics\DriverDiagnostics.h"
@@ -57,9 +56,6 @@ _Use_decl_annotations_ extern "C" NTSTATUS DriverEntry(
 	{
 		return Status;
 	}
-
-	// [LEGACY-PIPE]
-	StartNamedPipeServer();
 
 	return Status;
 }

--- a/tools/vdd_capture_test/trigger_monitor.ps1
+++ b/tools/vdd_capture_test/trigger_monitor.ps1
@@ -1,30 +1,8 @@
-$ErrorActionPreference='Stop'
-$pipes = [System.IO.Directory]::GetFiles('\\.\pipe\') | Where-Object { $_ -match 'Vdd|Zako' }
-Write-Host "--- pipes matching Vdd|Zako ---"
-$pipes | ForEach-Object { Write-Host $_ }
+$ErrorActionPreference = 'Stop'
 
-if (-not ($pipes | Where-Object { $_ -match 'ZakoVDDPipe' })) {
-    Write-Host "ZakoVDDPipe not present, abort." -ForegroundColor Yellow
-    exit 1
+$commandTool = Resolve-Path (Join-Path $PSScriptRoot '..\vdd_command\build\vdd_command.exe')
+Write-Host '--- sending CREATEMONITOR over IOCTL ---'
+& $commandTool CREATEMONITOR
+if ($LASTEXITCODE -ne 0) {
+    throw "vdd_command failed with exit code $LASTEXITCODE"
 }
-
-Write-Host "--- sending CREATEMONITOR ---"
-$client = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'ZakoVDDPipe', [System.IO.Pipes.PipeDirection]::InOut, [System.IO.Pipes.PipeOptions]::None)
-$client.Connect(2000)
-$client.ReadMode = [System.IO.Pipes.PipeTransmissionMode]::Message
-$bytes = [System.Text.Encoding]::Unicode.GetBytes("CREATEMONITOR")
-$client.Write($bytes, 0, $bytes.Length)
-$client.Flush()
-Write-Host ("Wrote " + $bytes.Length + " bytes")
-
-# Try to read response (best-effort)
-try {
-    $buf = New-Object byte[] 512
-    $n = $client.Read($buf, 0, $buf.Length)
-    if ($n -gt 0) {
-        Write-Host ("Response: " + [System.Text.Encoding]::Unicode.GetString($buf, 0, $n))
-    }
-} catch {
-    Write-Host "(no response)"
-}
-$client.Close()

--- a/tools/vdd_command/README.md
+++ b/tools/vdd_command/README.md
@@ -1,8 +1,7 @@
 # VDD command utility
 
 `vdd_command` sends UTF-16 commands through the ZakoVDD IOCTL device
-interface. It falls back to the administrator-only legacy pipe for older
-installed driver builds.
+interface.
 
 ```cmd
 build\vdd_command.exe CREATEMONITOR

--- a/tools/vdd_command/vdd_command.cpp
+++ b/tools/vdd_command/vdd_command.cpp
@@ -62,28 +62,6 @@ bool open_control_device(Handle& output, std::wstring& path, DWORD& native_error
   }
 }
 
-bool send_legacy_pipe_command(const std::wstring& command, DWORD& native_error) {
-  constexpr wchar_t kPipePath[] = L"\\\\.\\pipe\\ZakoVDDPipe";
-  if (!WaitNamedPipeW(kPipePath, 3000)) {
-    native_error = GetLastError();
-    return false;
-  }
-  Handle pipe;
-  pipe.value = CreateFileW(kPipePath, GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
-  if (pipe.value == INVALID_HANDLE_VALUE) {
-    native_error = GetLastError();
-    return false;
-  }
-  DWORD written = 0;
-  const DWORD bytes = static_cast<DWORD>(command.size() * sizeof(wchar_t));
-  if (!WriteFile(pipe.value, command.data(), bytes, &written, nullptr) || written != bytes) {
-    native_error = GetLastError();
-    return false;
-  }
-  FlushFileBuffers(pipe.value);
-  return true;
-}
-
 bool target_hdr_enabled(const DISPLAYCONFIG_PATH_INFO& path) {
   struct AdvancedColorInfo2 {
     DISPLAYCONFIG_DEVICE_INFO_HEADER header;
@@ -310,14 +288,8 @@ int wmain(int argc, wchar_t** argv) {
   std::wstring path;
   DWORD native_error = ERROR_SUCCESS;
   if (!open_control_device(device, path, native_error)) {
-    const DWORD interface_error = native_error;
-    if (!send_legacy_pipe_command(command, native_error)) {
-      std::wcerr << L"open_control_device=FAILED native_error=" << interface_error
-                 << L" legacy_pipe=FAILED native_error=" << native_error << L'\n';
-      return 3;
-    }
-    std::wcout << L"transport=legacy_pipe command=" << command << L" status=SUCCESS\n";
-    return 0;
+    std::wcerr << L"open_control_device=FAILED native_error=" << native_error << L'\n';
+    return 3;
   }
 
   DWORD returned = 0;


### PR DESCRIPTION
## 改了什么

- 删除驱动内的 Named Pipe 服务线程、同步 `ConnectNamedPipe` 接受循环和卸载等待
- 删除 Pipe 专属的全局句柄、响应写回以及 `GETSETTINGS` / 字符串 `PING` 处理器
- 保留统一的 IOCTL 命令分发与专用 `IOCTL_VDD_PING`
- 将 `vdd_command` 和监视器触发脚本改为 IOCTL-only
- 清理所有迁移期 Pipe 注释和接口参数

## 为什么

WUDFHost 转储显示卸载线程卡在 `StopNamedPipeServer -> WaitForSingleObject(INFINITE)`，而服务线程阻塞于同步 `ConnectNamedPipe`；用于唤醒它的 `CreateFileW` 又可能失败。于是设备重启或驱动替换会等满 60 秒，并触发 UMDF 10111/10120。把旧服务完全移除后，驱动生命周期只剩 WDF/IOCTL，不再需要手工唤醒后台线程。

这个 PR 独立基于 `main`，不包含 #21 的 monitor-description/mode 刷新改动。

## 验证

- Release x64 `ZakoVDD.sln` 构建通过，Signability 无警告/错误
- `tools/vdd_command/build_consumer.bat` 通过
- 本机无 Pipe 版本覆盖安装从旧版的 62.285 秒降到 1.243 秒
- 设备重启 467 ms；此前连续三次为 337/302/295 ms
- `IDDCXVERSION` IOCTL 成功，设备状态 `CM_PROB_NONE`
- 重启窗口内无新增 UMDF/HostTimeout 事件，运行时无 `ZakoVDDPipe`
- 全源码扫描无 Pipe 服务/API 残留


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 控制命令统一通过设备接口发送，支持 UTF-16 命令缓冲区。
  * 更新命令工具与监视器创建测试流程，改用直接设备通信。

* **改进**
  * 移除旧版命名管道传输及相关回退机制，通信路径更加统一。
  * 设备接口创建失败时将明确报告错误，避免继续执行不完整的初始化。

* **文档**
  * 更新命令工具说明，移除旧版命名管道相关描述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->