### PR TITLE
fix(win10): make compatibility driver IOCTL-only

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,17 +3,19 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - main
       - master
       - sunshine
     tags:
       - 'v*'
   pull_request_target:
     branches:
+      - main
       - master
       - sunshine
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         configuration: [Release]
@@ -26,16 +28,25 @@ jobs:
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: '[17.0,18.0)'
 
       - name: Install WDK
         shell: pwsh
         run: |
-          # Check if WDK is already installed
+          # Check if WDK and its VS2022 MSBuild tasks are installed.
+          $requiredVsVersion = "17.0"
+          $wdkTaskPattern = "C:\Program Files*\Windows Kits\10\build\*\bin\Microsoft.DriverKit.Build.Tasks.$requiredVsVersion.dll"
           $wdfHeader = Get-ChildItem "C:\Program Files*\Windows Kits\10\Include\*\wdf" -Directory -ErrorAction SilentlyContinue |
                        Sort-Object { $_.Parent.Name } -Descending |
                        Select-Object -First 1
-          if ($wdfHeader) {
+          $wdkTask = Get-ChildItem $wdkTaskPattern -ErrorAction SilentlyContinue |
+                     Sort-Object { $_.Directory.Parent.Name } -Descending |
+                     Select-Object -First 1
+
+          if ($wdfHeader -and $wdkTask) {
             Write-Host "WDK already installed at: $($wdfHeader.FullName)"
+            Write-Host "WDK MSBuild task found at: $($wdkTask.FullName)"
           } else {
             Write-Host "Installing WDK..."
             $wdkUrl = "https://go.microsoft.com/fwlink/?linkid=2272234"
@@ -43,20 +54,52 @@ jobs:
             Invoke-WebRequest -Uri $wdkUrl -OutFile $wdkInstaller -UseBasicParsing
             $proc = Start-Process -FilePath $wdkInstaller -ArgumentList "/quiet", "/norestart", "/features", "+" -Wait -NoNewWindow -PassThru
             Write-Host "WDK installer exit code: $($proc.ExitCode)"
-          }
-
-          # Install WDK VSIX for MSBuild integration
-          $vsixFiles = Get-ChildItem "C:\Program Files*\Windows Kits\10\Vsix\*\WDK.vsix" -Recurse -ErrorAction SilentlyContinue
-          if ($vsixFiles) {
-            $vsixInstaller = "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\VSIXInstaller.exe"
-            if (Test-Path $vsixInstaller) {
-              foreach ($vsix in $vsixFiles) {
-                Write-Host "Installing VSIX: $($vsix.FullName)"
-                $p = Start-Process -FilePath $vsixInstaller -ArgumentList "/q", $vsix.FullName -Wait -NoNewWindow -PassThru
-                Write-Host "VSIX installer exit code: $($p.ExitCode)"
-              }
+            if ($proc.ExitCode -ne 0) {
+              Write-Error "WDK installer failed with exit code $($proc.ExitCode)"
+              exit 1
             }
           }
+
+          # Install WDK VSIX for MSBuild integration into the selected VS2022 instance.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            Write-Error "vswhere.exe not found"
+            exit 1
+          }
+
+          $vsInstall = & $vswhere -products * -requires Microsoft.Component.MSBuild -version "[17.0,18.0)" -property installationPath -latest
+          if (-not $vsInstall) {
+            Write-Error "Visual Studio 2022 with MSBuild was not found"
+            exit 1
+          }
+          Write-Host "Using Visual Studio: $vsInstall"
+
+          $vsixInstaller = Join-Path $vsInstall "Common7\IDE\VSIXInstaller.exe"
+          if (-not (Test-Path $vsixInstaller)) {
+            Write-Error "VSIXInstaller.exe not found at $vsixInstaller"
+            exit 1
+          }
+
+          $vsixFiles = Get-ChildItem "C:\Program Files*\Windows Kits\10\Vsix\*\WDK.vsix" -Recurse -ErrorAction SilentlyContinue
+          if (-not $vsixFiles) {
+            Write-Error "WDK.vsix not found"
+            exit 1
+          }
+
+          foreach ($vsix in $vsixFiles) {
+            Write-Host "Installing VSIX: $($vsix.FullName)"
+            $p = Start-Process -FilePath $vsixInstaller -ArgumentList "/q", $vsix.FullName -Wait -NoNewWindow -PassThru
+            Write-Host "VSIX installer exit code: $($p.ExitCode)"
+          }
+
+          $wdkTask = Get-ChildItem $wdkTaskPattern -ErrorAction SilentlyContinue |
+                     Sort-Object { $_.Directory.Parent.Name } -Descending |
+                     Select-Object -First 1
+          if (-not $wdkTask) {
+            Write-Error "WDK MSBuild task for VS $requiredVsVersion not found ($wdkTaskPattern)"
+            exit 1
+          }
+          Write-Host "Verified WDK MSBuild task: $($wdkTask.FullName)"
 
       - name: Build the driver
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -65,6 +65,14 @@ jobs:
             }
           }
 
+          $wdkTask = Get-ChildItem $wdkTaskPattern -ErrorAction SilentlyContinue |
+                     Sort-Object { $_.Directory.Parent.Name } -Descending |
+                     Select-Object -First 1
+          if ($wdkTask) {
+            Write-Host "Verified WDK MSBuild task after setup: $($wdkTask.FullName)"
+            exit 0
+          }
+
           # Install WDK VSIX for MSBuild integration into the selected VS2022 instance.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           if (-not (Test-Path $vswhere)) {

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,7 @@
 name: Virtual Display Driver Building
+env:
+  VS_VERSION_RANGE: '[17.0,18.0)'
+  REQUIRED_VS_VERSION: '17.0'
 on:
   workflow_dispatch:
   push:
@@ -6,6 +9,7 @@ on:
       - main
       - master
       - sunshine
+      - win10
     tags:
       - 'v*'
   pull_request_target:
@@ -13,6 +17,7 @@ on:
       - main
       - master
       - sunshine
+      - win10
 jobs:
   build:
     runs-on: windows-2022
@@ -29,13 +34,13 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
         with:
-          vs-version: '[17.0,18.0)'
+          vs-version: ${{ env.VS_VERSION_RANGE }}
 
       - name: Install WDK
         shell: pwsh
         run: |
           # Check if WDK and its VS2022 MSBuild tasks are installed.
-          $requiredVsVersion = "17.0"
+          $requiredVsVersion = $env:REQUIRED_VS_VERSION
           $wdkTaskPattern = "C:\Program Files*\Windows Kits\10\build\*\bin\Microsoft.DriverKit.Build.Tasks.$requiredVsVersion.dll"
           $wdfHeader = Get-ChildItem "C:\Program Files*\Windows Kits\10\Include\*\wdf" -Directory -ErrorAction SilentlyContinue |
                        Sort-Object { $_.Parent.Name } -Descending |
@@ -67,7 +72,7 @@ jobs:
             exit 1
           }
 
-          $vsInstall = & $vswhere -products * -requires Microsoft.Component.MSBuild -version "[17.0,18.0)" -property installationPath -latest
+          $vsInstall = & $vswhere -products * -requires Microsoft.Component.MSBuild -version $env:VS_VERSION_RANGE -property installationPath -latest
           if (-not $vsInstall) {
             Write-Error "Visual Studio 2022 with MSBuild was not found"
             exit 1
@@ -90,6 +95,10 @@ jobs:
             Write-Host "Installing VSIX: $($vsix.FullName)"
             $p = Start-Process -FilePath $vsixInstaller -ArgumentList "/q", $vsix.FullName -Wait -NoNewWindow -PassThru
             Write-Host "VSIX installer exit code: $($p.ExitCode)"
+            if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 1001) {
+              Write-Error "VSIX install failed for $($vsix.FullName) (exit code $($p.ExitCode))"
+              exit 1
+            }
           }
 
           $wdkTask = Get-ChildItem $wdkTaskPattern -ErrorAction SilentlyContinue |

--- a/Common/Include/vdd_control_ioctl.h
+++ b/Common/Include/vdd_control_ioctl.h
@@ -1,49 +1,132 @@
-// Shared IOCTL contract between the ZakoVDD UMDF driver and external callers
-// (currently Sunshine). This header MUST stay byte-compatible across both
-// projects; if you change anything here, mirror the change to the consumer
-// (e.g. Sunshine src/display_device/vdd_control_ioctl.h).
-//
-// Why IOCTL instead of the legacy named pipe (\\.\pipe\ZakoVDDPipe):
-//   The pipe server lives inside the WUDFHost.exe process that hosts the
-//   indirect display driver. When the last IDDCX monitor is destroyed, the
-//   reflector eventually recycles WUDFHost.exe and the pipe vanishes,
-//   leaving subsequent connect attempts to time out for ~6s before a costly
-//   DevManView disable_enable kicks the device back to life. Using a control
-//   device interface lets CreateFile() PnP-wake the driver transparently and
-//   removes the race entirely.
+/**
+ * @file vdd_control_ioctl.h
+ * @brief Authoritative IOCTL contract between Sunshine and the ZakoVDD driver.
+ *
+ * This header MUST stay byte-for-byte identical across the Sunshine and
+ * Virtual-Display-Driver repositories. The canonical copy paths are:
+ *   Sunshine: `src/display_device/vdd_control_ioctl.h`
+ *   VDD: `Common/Include/vdd_control_ioctl.h`
+ * The copies are intentionally duplicated to keep each repo self-contained.
+ *
+ * Transport summary:
+ *   The driver exposes a custom WDF device interface
+ *   (`GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`). Opening this interface with
+ *   `CreateFileW` PnP-wakes the IddCx driver back into D0 and remains valid
+ *   across WUDFHost recycling.
+ *
+ *   `IOCTL_VDD_COMMAND` carries a NUL-terminated UTF-16 command buffer
+ *   (e.g. `RELOAD_DRIVER`, `CREATEMONITOR ...`, `DESTROYMONITOR`).
+ *
+ *   `IOCTL_VDD_PING` is a cheap liveness probe (no payload).
+ *
+ *   `IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS` is the v2 frame-channel negotiation
+ *   probe. Drivers that do not implement it are treated as legacy named-object
+ *   frame producers by Sunshine.
+ *
+ *   `IOCTL_VDD_OPEN_FRAME_CHANNEL` asks the driver to duplicate an unnamed
+ *   producer-owned frame channel into the requesting Sunshine process. The
+ *   returned handle values are valid only in `TargetProcessId`, which must be
+ *   the process that issued the IOCTL.
+ *
+ *   `DesiredSlots` is a compatibility guard, not a request for the driver to
+ *   resize its producer ring. Use 0 for the driver default, or the exact
+ *   `MaxSharedSlots` value returned by `IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS`.
+ */
 
 #pragma once
 
-#include <initguid.h>
+#if defined(_WIN32) || defined(_WIN64)
+
+#if defined(INITGUID)
+#define VDD_CONTROL_RESTORE_INITGUID
+#undef INITGUID
+#endif
+
 #include <Windows.h>
+#include <winioctl.h>
+
+#if defined(VDD_CONTROL_RESTORE_INITGUID)
+#define INITGUID
+#undef VDD_CONTROL_RESTORE_INITGUID
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // {DA9F8C2B-7E4F-49A1-9D4E-6F2B0E1A0C4D}
+#define ZAKO_VDD_CONTROL_GUID_INIT \
+  { 0xDA9F8C2B, 0x7E4F, 0x49A1, { 0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D } }
+
 DEFINE_GUID(GUID_DEVINTERFACE_ZAKO_VDD_CONTROL,
-    0xDA9F8C2B, 0x7E4F, 0x49A1, 0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D);
+  0xDA9F8C2B, 0x7E4F, 0x49A1, 0x9D, 0x4E, 0x6F, 0x2B, 0x0E, 0x1A, 0x0C, 0x4D);
 
-// Single dispatch IOCTL. The input buffer is a null-terminated UTF-16 string
-// using the same command grammar as the legacy named pipe protocol so the
-// in-driver dispatcher can be shared verbatim. The output buffer (optional)
-// receives a response payload (UTF-8 or UTF-16 depending on the command;
-// today only PING/GETSETTINGS write a response and the SDR/HDR commands
-// do not, matching the pipe behaviour).
-//
-// METHOD_BUFFERED: the kernel copies the input/output buffers, so the
-// driver works on stable, non-volatile memory and we don't have to worry
-// about the caller's buffer disappearing mid-handler.
-//
-// FILE_WRITE_DATA matches the pipe's GENERIC_READ|GENERIC_WRITE access mask
-// expectations and matches the SDDL-allows-everyone semantics of the legacy
-// pipe (D:(A;;GA;;;WD)). If you tighten this later remember to update both
-// the driver registration and the Sunshine SetupDi code path.
-#define ZAKO_VDD_DEVICE_TYPE   FILE_DEVICE_UNKNOWN
-
+// IOCTL function codes carved out of the driver-defined range (0x800+).
 #define IOCTL_VDD_COMMAND \
-    CTL_CODE(ZAKO_VDD_DEVICE_TYPE, 0x800, METHOD_BUFFERED, FILE_WRITE_DATA)
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_BUFFERED, FILE_WRITE_DATA)
 
-// Optional probe IOCTL. Returns STATUS_SUCCESS with no payload if the
-// driver is alive. Sunshine uses this as a cheap "is the IOCTL channel
-// available?" check so it can short-circuit to disable_enable when the
-// driver is missing instead of hanging on slow command IOCTLs.
 #define IOCTL_VDD_PING \
-    CTL_CODE(ZAKO_VDD_DEVICE_TYPE, 0x801, METHOD_BUFFERED, FILE_READ_ACCESS)
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+#define IOCTL_VDD_QUERY_FRAME_CHANNEL_CAPS \
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x802, METHOD_BUFFERED, FILE_READ_ACCESS)
+
+#define IOCTL_VDD_OPEN_FRAME_CHANNEL \
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x803, METHOD_BUFFERED, FILE_READ_DATA | FILE_WRITE_DATA)
+
+#define VDD_FRAME_CHANNEL_CAPS_VERSION 1u
+#define VDD_FRAME_CHANNEL_OPEN_VERSION 1u
+#define VDD_FRAME_CHANNEL_MAX_SLOTS 8u
+#define VDD_FRAME_CHANNEL_FLAG_SEALED_BORROW 0x00000001u
+#define VDD_FRAME_CHANNEL_FLAG_UNNAMED_HANDLES 0x00000002u
+#define VDD_FRAME_CHANNEL_FLAG_STRICT_DACL 0x00000004u
+
+typedef struct VDD_FRAME_CHANNEL_CAPS {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 Flags;
+  UINT32 MaxSharedSlots;
+  UINT32 MetadataSize;
+  UINT32 Reserved0;
+  UINT64 Reserved1;
+} VDD_FRAME_CHANNEL_CAPS;
+
+typedef struct VDD_FRAME_CHANNEL_OPEN_REQUEST {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 MonitorIndex;
+  UINT32 RequiredFlags;
+  UINT32 TargetProcessId;
+  UINT32 DesiredSlots;
+  UINT32 AdapterLuidLowPart;
+  INT32 AdapterLuidHighPart;
+  UINT64 Reserved0;
+} VDD_FRAME_CHANNEL_OPEN_REQUEST;
+
+typedef struct VDD_FRAME_CHANNEL_SLOT_HANDLE {
+  UINT64 TextureHandle;
+  UINT64 Reserved0;
+} VDD_FRAME_CHANNEL_SLOT_HANDLE;
+
+typedef struct VDD_FRAME_CHANNEL_OPEN_RESPONSE {
+  UINT32 Size;
+  UINT32 Version;
+  UINT32 Flags;
+  UINT32 SlotCount;
+  UINT32 MetadataSize;
+  UINT32 Reserved0;
+  UINT64 MetadataHandle;
+  UINT64 FrameReadyEventHandle;
+  VDD_FRAME_CHANNEL_SLOT_HANDLE Slots[VDD_FRAME_CHANNEL_MAX_SLOTS];
+} VDD_FRAME_CHANNEL_OPEN_RESPONSE;
+
+#ifdef __cplusplus
+}
+
+static_assert(sizeof(VDD_FRAME_CHANNEL_CAPS) == 32, "VDD_FRAME_CHANNEL_CAPS layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_OPEN_REQUEST) == 40, "VDD_FRAME_CHANNEL_OPEN_REQUEST layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_SLOT_HANDLE) == 16, "VDD_FRAME_CHANNEL_SLOT_HANDLE layout must stay stable");
+static_assert(sizeof(VDD_FRAME_CHANNEL_OPEN_RESPONSE) == 40 + 16 * VDD_FRAME_CHANNEL_MAX_SLOTS, "VDD_FRAME_CHANNEL_OPEN_RESPONSE layout must stay stable");
+#endif
+
+#endif  // _WIN32 || _WIN64

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -43,40 +43,21 @@ Environment:
 #include <set>
 #include <atomic>
 
-// =====================================================================
-// Transitional named-pipe transport
-// ---------------------------------------------------------------------
-// All pipe-related code in this translation unit is marked with the
-// tag [LEGACY-PIPE] in a leading comment so it can be removed in a
-// single mechanical pass once every Sunshine release in the wild
-// speaks IOCTL natively. To strip:
-//   1. grep -nE '\[LEGACY-PIPE\]' Driver.cpp and delete each tagged
-//      block (signature + body, plus the call site in DriverEntry /
-//      EvtDriverUnload).
-//   2. Drop PIPE_NAME, hPipeThread, g_Running (pipe-only), g_pipeHandle,
-//      sendLogsThroughPipe, SendToPipe, the SendLogsThroughPipe registry
-//      hook, HandleClient, StartNamedPipeServer, StopNamedPipeServer.
-//   3. Drop the `hPipeForResponse` parameter on DispatchVddCommandBuffer
-//      and remove the GETSETTINGS WriteFile guarded branch.
-// The IOCTL transport (VirtualDisplayDriverIoDeviceControl +
-// GUID_DEVINTERFACE_ZAKO_VDD_CONTROL) and DispatchVddCommandBuffer
-// remain untouched.
-// =====================================================================
+extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID_INIT;
 
-// [LEGACY-PIPE]
-#define PIPE_NAME L"\\\\.\\pipe\\ZakoVDDPipe"
+#define ZAKO_IDDCX_STRUCT_INIT(obj, type) \
+	do \
+	{ \
+		RtlZeroMemory(&(obj), sizeof(obj)); \
+		(obj).Size = IDD_STRUCTURE_SIZE(type); \
+	} while (0)
 
 #pragma comment(lib, "xmllite.lib")
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "shell32.lib")
 
-// [LEGACY-PIPE]
-HANDLE hPipeThread = NULL;
-std::atomic<bool> g_Running{true};
 mutex g_Mutex;
 mutex g_DataMutex; // Protects monitorModes, s_KnownMonitorModes2, numVirtualDisplays, gpuname
-// [LEGACY-PIPE]
-HANDLE g_pipeHandle = INVALID_HANDLE_VALUE;
 WDFDEVICE g_GlobalDevice = nullptr;
 
 using namespace std;
@@ -178,9 +159,6 @@ std::atomic<bool> vrrEnabled{false};
 std::atomic<bool> hardwareCursor{false};
 std::atomic<bool> preventManufacturerSpoof{false};
 std::atomic<bool> edidCeaOverride{false};
-// [LEGACY-PIPE]
-std::atomic<bool> sendLogsThroughPipe{true};
-
 // Mouse settings
 std::atomic<bool> alphaCursorSupport{true};
 int CursorMaxX = 128;
@@ -200,7 +178,6 @@ std::map<std::wstring, std::pair<std::wstring, std::wstring>> SettingsQueryMap =
 
 	{L"PreventMonitorSpoof", {L"PREVENTMONITORSPOOF", L"PreventSpoof"}},
 	{L"EdidCeaOverride", {L"EDIDCEAOVERRIDE", L"EdidCeaOverride"}},
-	{L"SendLogsThroughPipe", {L"SENDLOGSTHROUGHPIPE", L"SendLogsThroughPipe"}},
 	// Cursor Begin
 	{L"HardwareCursorEnabled", {L"HARDWARECURSOR", L"HardwareCursor"}},
 	{L"AlphaCursorSupport", {L"ALPHACURSORSUPPORT", L"AlphaCursorSupport"}},
@@ -692,17 +669,6 @@ void float_to_vsync(float refresh_rate, int &num, int &den)
 	den /= divisor;
 }
 
-// [LEGACY-PIPE] entire function
-void SendToPipe(const std::string &logMessage)
-{
-	if (g_pipeHandle != INVALID_HANDLE_VALUE)
-	{
-		DWORD bytesWritten;
-		DWORD logMessageSize = static_cast<DWORD>(logMessage.size());
-		WriteFile(g_pipeHandle, logMessage.c_str(), logMessageSize, &bytesWritten, NULL);
-	}
-}
-
 void vddlog(const char *type, const char *message)
 {
 	// Emit to ETW first - independent of file-logging toggle. TraceLogging
@@ -744,7 +710,7 @@ void vddlog(const char *type, const char *message)
 		logType = "INFO";
 		break;
 	case 'p':
-		logType = "PIPE";
+		logType = "CONTROL";
 		break;
 	case 'd':
 		logType = "DEBUG";
@@ -854,14 +820,6 @@ void vddlog(const char *type, const char *message)
 	fprintf(logFile, "[%s] [%s] %s\n", ss.str().c_str(), logType.c_str(), message);
 	fflush(logFile); // Ensure data is written immediately
 
-	// [LEGACY-PIPE] Send through pipe if enabled
-	if (sendLogsThroughPipe && g_pipeHandle != INVALID_HANDLE_VALUE)
-	{
-		string logMessage = ss.str() + " [" + logType + "] " + message + "\n";
-		DWORD bytesWritten;
-		DWORD logMessageSize = static_cast<DWORD>(logMessage.size());
-		WriteFile(g_pipeHandle, logMessage.c_str(), logMessageSize, &bytesWritten, NULL);
-	}
 }
 
 void LogIddCxVersion()
@@ -999,7 +957,7 @@ static const char *VddTypeToCategory(const char *type)
 	case 'i': return "info";
 	case 'c': return "companion";
 	case 'd': return "debug";
-	case 'p': return "pipe";
+	case 'p': return "control";
 	case 't': return "test";
 	default:  return "log";
 	}
@@ -1642,16 +1600,9 @@ void toggleSettingImpl(HANDLE hPipe, wchar_t *param, const wchar_t *settingName,
 	}
 }
 
-// Centralised command-buffer dispatch shared by both the legacy named-pipe
-// transport (HandleClient) and the new IOCTL transport
-// (VirtualDisplayDriverIoDeviceControl).
-//
-// `buffer` MUST be a writable, null-terminated UTF-16 string of at most
-// 2048 wchar_t. `hPipeForResponse` is the response sink for the few
-// commands that write back via WriteFile/SendToPipe (GETSETTINGS / PING);
-// pass INVALID_HANDLE_VALUE for IOCTL callers and those response handlers
-// will silently no-op (Sunshine never relies on the response payload of
-// any command it sends, so this is intentional and safe).
+// Dispatch a writable, null-terminated UTF-16 command received through IOCTL.
+// The response handle is reserved for legacy command handlers; Sunshine does
+// not request response payloads.
 void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 {
 	struct Command
@@ -1669,7 +1620,7 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 
 	auto handleLogDebug = [](HANDLE hPipe, wchar_t *param)
 	{
-		toggleSettingImpl(hPipe, param, L"debuglogging", "Pipe debugging enabled", "Debugging disabled");
+		toggleSettingImpl(hPipe, param, L"debuglogging", "Debug logging enabled", "Debug logging disabled");
 	};
 
 	auto handleLogging = [](HANDLE hPipe, wchar_t *param)
@@ -1834,10 +1785,7 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 
 	auto handlePing = [](HANDLE, wchar_t *)
 	{
-		// SendToPipe checks g_pipeHandle internally; for IOCTL callers
-		// g_pipeHandle is INVALID_HANDLE_VALUE so this is a logged no-op.
-		SendToPipe("PONG");
-		vddlog("p", "Heartbeat Ping");
+		vddlog("d", "IOCTL heartbeat ping");
 	};
 
 	auto handleCreateMonitor = [](HANDLE, wchar_t *param)
@@ -2192,28 +2140,6 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 	}
 }
 
-// [LEGACY-PIPE] entire function -- pipe-side wrapper around DispatchVddCommandBuffer
-void HandleClient(HANDLE hPipe)
-{
-	g_pipeHandle = hPipe;
-	vddlog("p", "Client Handling Enabled");
-	wchar_t buffer[2048];
-	DWORD bytesRead;
-	BOOL result = ReadFile(hPipe, buffer, sizeof(buffer) - sizeof(wchar_t), &bytesRead, NULL);
-	if (result && bytesRead != 0)
-	{
-		buffer[bytesRead / sizeof(wchar_t)] = L'\0';
-		wstring bufferwstr(buffer);
-		string bufferstr = WStringToString(bufferwstr);
-		vddlog("p", bufferstr.c_str());
-
-		DispatchVddCommandBuffer(hPipe, buffer);
-	}
-	DisconnectNamedPipe(hPipe);
-	CloseHandle(hPipe);
-	g_pipeHandle = INVALID_HANDLE_VALUE;
-}
-
 // IddCx redirects every IRP_MJ_DEVICE_CONTROL into its own internal queue
 // before any default WDF queue ever sees it. The only way to receive a
 // custom IOCTL in an IddCx driver is through this callback registered via
@@ -2251,8 +2177,7 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			return;
 		}
 
-		// Mirror the legacy named-pipe HandleClient buffer (2048 wchar_t).
-		// Anything larger is almost certainly malformed input.
+		// Commands are bounded to the parser's 2048-wchar_t local buffer.
 		if (InputBufferLength > 2048 * sizeof(wchar_t))
 		{
 			WdfRequestComplete(Request, STATUS_BUFFER_OVERFLOW);
@@ -2286,9 +2211,6 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			string bufferstr = WStringToString(bufferwstr);
 			vddlog("p", ("[IOCTL] " + bufferstr).c_str());
 
-			// Pass INVALID_HANDLE_VALUE so response-emitting handlers
-			// (GETSETTINGS / PING) silently skip their WriteFile path.
-			// Sunshine never observes those responses anyway.
 			DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, buffer);
 		}
 		catch (const std::exception &e)
@@ -2309,110 +2231,6 @@ VOID VirtualDisplayDriverIoDeviceControl(
 	default:
 		WdfRequestComplete(Request, STATUS_NOT_SUPPORTED);
 		return;
-	}
-}
-
-
-// [LEGACY-PIPE] entire function -- accept-loop thread for the named pipe
-DWORD WINAPI NamedPipeServer(LPVOID lpParam)
-{
-	UNREFERENCED_PARAMETER(lpParam);
-
-	SECURITY_ATTRIBUTES sa;
-	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
-	sa.bInheritHandle = FALSE;
-	const wchar_t *sddl = L"D:(A;;GA;;;WD)";
-	vddlog("d", "Starting pipe with parameters: D:(A;;GA;;;WD)");
-	if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(
-			sddl, SDDL_REVISION_1, &sa.lpSecurityDescriptor, NULL))
-	{
-		DWORD ErrorCode = GetLastError();
-		string errorMsg = to_string(ErrorCode);
-		vddlog("e", errorMsg.c_str());
-		return 1;
-	}
-	HANDLE hPipe;
-	while (g_Running)
-	{
-		hPipe = CreateNamedPipeW(
-			PIPE_NAME,
-			PIPE_ACCESS_DUPLEX,
-			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
-			PIPE_UNLIMITED_INSTANCES,
-			512, 512,
-			0,
-			&sa);
-
-		if (hPipe == INVALID_HANDLE_VALUE)
-		{
-			DWORD ErrorCode = GetLastError();
-			string errorMsg = to_string(ErrorCode);
-			vddlog("e", errorMsg.c_str());
-			LocalFree(sa.lpSecurityDescriptor);
-			return 1;
-		}
-
-		BOOL connected = ConnectNamedPipe(hPipe, NULL) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
-		if (connected)
-		{
-			vddlog("p", "Client Connected");
-			HandleClient(hPipe);
-		}
-		else
-		{
-			CloseHandle(hPipe);
-		}
-	}
-	LocalFree(sa.lpSecurityDescriptor);
-	return 0;
-}
-
-// [LEGACY-PIPE] entire function
-void StartNamedPipeServer()
-{
-	vddlog("p", "Starting Pipe");
-	hPipeThread = CreateThread(NULL, 0, NamedPipeServer, NULL, 0, NULL);
-	if (hPipeThread == NULL)
-	{
-		DWORD ErrorCode = GetLastError();
-		string errorMsg = to_string(ErrorCode);
-		vddlog("e", errorMsg.c_str());
-	}
-	else
-	{
-		vddlog("p", "Pipe created");
-	}
-}
-
-// [LEGACY-PIPE] entire function
-void StopNamedPipeServer()
-{
-	vddlog("p", "Stopping Pipe");
-	{
-		lock_guard<mutex> lock(g_Mutex);
-		g_Running = false;
-	}
-	if (hPipeThread)
-	{
-		HANDLE hPipe = CreateFileW(
-			PIPE_NAME,
-			GENERIC_READ | GENERIC_WRITE,
-			0,
-			NULL,
-			OPEN_EXISTING,
-			0,
-			NULL);
-
-		if (hPipe != INVALID_HANDLE_VALUE)
-		{
-			DisconnectNamedPipe(hPipe);
-			CloseHandle(hPipe);
-		}
-
-		WaitForSingleObject(hPipeThread, INFINITE);
-		CloseHandle(hPipeThread);
-		hPipeThread = NULL;
-		vddlog("p", "Stopped Pipe");
 	}
 }
 
@@ -2513,9 +2331,6 @@ VOID EvtDriverUnload(
 		Sleep(100);
 	}
 
-	// [LEGACY-PIPE] Stop the named pipe server
-	StopNamedPipeServer();
-
 	vddlog("i", "Driver unload completed");
 }
 
@@ -2539,8 +2354,6 @@ _Use_decl_annotations_ extern "C" NTSTATUS DriverEntry(
 	customEdid = EnabledQuery(L"CustomEdidEnabled");
 	preventManufacturerSpoof = EnabledQuery(L"PreventMonitorSpoof");
 	edidCeaOverride = EnabledQuery(L"EdidCeaOverride");
-	// [LEGACY-PIPE]
-	sendLogsThroughPipe = EnabledQuery(L"SendLogsThroughPipe");
 
 	// colour
 	HDRPlus = EnabledQuery(L"HDRPlusEnabled");
@@ -2590,9 +2403,6 @@ _Use_decl_annotations_ extern "C" NTSTATUS DriverEntry(
 	{
 		return Status;
 	}
-
-	// [LEGACY-PIPE]
-	StartNamedPipeServer();
 
 	return Status;
 }
@@ -3064,25 +2874,18 @@ _Use_decl_annotations_
 		return Status;
 	}
 
-	// Expose a custom device interface so external callers (Sunshine) can
-	// reach us via DeviceIoControl over CreateFile(\\?\GUID...). This is the
-	// transport that survives WUDFHost recycling: opening the interface
-	// PnP-wakes the driver back into D0 transparently. The legacy named pipe
-	// transport remains active in parallel for backwards compatibility but
-	// is now only the fallback path.
+	// Expose the required IOCTL control interface. Without it Sunshine cannot
+	// operate the virtual display, so fail DeviceAdd instead of leaving a
+	// running but unusable adapter.
 	Status = WdfDeviceCreateDeviceInterface(Device, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, NULL);
 	if (!NT_SUCCESS(Status))
 	{
 		logStream.str("");
-		logStream << "WdfDeviceCreateDeviceInterface failed with status: " << Status
-		          << " - IOCTL transport will be unavailable, pipe transport still works";
+		logStream << "WdfDeviceCreateDeviceInterface failed with status: " << Status;
 		vddlog("e", logStream.str().c_str());
-		// Non-fatal: pipe transport remains usable, so don't abort device add.
+		return Status;
 	}
-	else
-	{
-		vddlog("d", "Registered Zako VDD control device interface");
-	}
+	vddlog("d", "Registered Zako VDD control device interface");
 
 	// Create a new device context object and attach it to the WDF device object
 	/*
@@ -4713,7 +4516,7 @@ void IndirectDeviceContext::InitAdapter()
 	logStream.str("");
 
 	IDDCX_ADAPTER_CAPS AdapterCaps = {};
-	AdapterCaps.Size = sizeof(AdapterCaps);
+	ZAKO_IDDCX_STRUCT_INIT(AdapterCaps, IDDCX_ADAPTER_CAPS);
 
 	if (IDD_IS_FUNCTION_AVAILABLE(IddCxSwapChainReleaseAndAcquireBuffer2))
 	{
@@ -4749,7 +4552,7 @@ void IndirectDeviceContext::InitAdapter()
 
 	// Declare basic feature support for the adapter (required)
 	AdapterCaps.MaxMonitorsSupported = numVirtualDisplays;
-	AdapterCaps.EndPointDiagnostics.Size = sizeof(AdapterCaps.EndPointDiagnostics);
+	ZAKO_IDDCX_STRUCT_INIT(AdapterCaps.EndPointDiagnostics, IDDCX_ENDPOINT_DIAGNOSTIC_INFO);
 	AdapterCaps.EndPointDiagnostics.GammaSupport = IDDCX_FEATURE_IMPLEMENTATION_NONE;
 	AdapterCaps.EndPointDiagnostics.TransmissionType = IDDCX_TRANSMISSION_TYPE_WIRED_OTHER;
 
@@ -4760,7 +4563,7 @@ void IndirectDeviceContext::InitAdapter()
 
 	// Declare your hardware and firmware versions (required)
 	IDDCX_ENDPOINT_VERSION Version = {};
-	Version.Size = sizeof(Version);
+	ZAKO_IDDCX_STRUCT_INIT(Version, IDDCX_ENDPOINT_VERSION);
 	Version.MajorVer = 1;
 	AdapterCaps.EndPointDiagnostics.pFirmwareVersion = &Version;
 	AdapterCaps.EndPointDiagnostics.pHardwareVersion = &Version;
@@ -4843,7 +4646,6 @@ void IndirectDeviceContext::InitAdapter()
 void IndirectDeviceContext::FinishInit()
 {
 	Options.Adapter.apply(m_Adapter);
-	SendToPipe("FinishInit");
 	vddlog("i", "Applied Adapter configs.");
 }
 
@@ -4994,7 +4796,7 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 	}
 
 	IDDCX_MONITOR_INFO MonitorInfo = {};
-	MonitorInfo.Size = sizeof(MonitorInfo);
+	ZAKO_IDDCX_STRUCT_INIT(MonitorInfo, IDDCX_MONITOR_INFO);
 	MonitorInfo.MonitorType = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI;
 	MonitorInfo.ConnectorIndex = index;
 	MonitorInfo.MonitorDescription.Size = sizeof(MonitorInfo.MonitorDescription);
@@ -5333,7 +5135,7 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 			m_MouseEvents[Monitor] = hMouseEvent;
 
 			IDDCX_CURSOR_CAPS cursorInfo = {};
-			cursorInfo.Size = sizeof(cursorInfo);
+			ZAKO_IDDCX_STRUCT_INIT(cursorInfo, IDDCX_CURSOR_CAPS);
 			cursorInfo.ColorXorCursorSupport = IDDCX_XOR_CURSOR_SUPPORT_FULL;
 			cursorInfo.AlphaCursorSupport = alphaCursorSupport;
 
@@ -5711,7 +5513,7 @@ _Use_decl_annotations_
 		// Copy the known modes to the output buffer
 		for (DWORD ModeIndex = 0; ModeIndex < localModes.size(); ModeIndex++)
 		{
-			pInArgs->pMonitorModes[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE);
+			ZAKO_IDDCX_STRUCT_INIT(pInArgs->pMonitorModes[ModeIndex], IDDCX_MONITOR_MODE);
 			pInArgs->pMonitorModes[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
 			pInArgs->pMonitorModes[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
 		}
@@ -5779,7 +5581,7 @@ void CreateTargetMode(DISPLAYCONFIG_VIDEO_SIGNAL_INFO &Mode, UINT Width, UINT He
 
 void CreateTargetMode(IDDCX_TARGET_MODE &Mode, UINT Width, UINT Height, UINT VSyncNum, UINT VSyncDen)
 {
-	Mode.Size = sizeof(Mode);
+	ZAKO_IDDCX_STRUCT_INIT(Mode, IDDCX_TARGET_MODE);
 	CreateTargetMode(Mode.TargetVideoSignalInfo.targetVideoSignalInfo, Width, Height, VSyncNum, VSyncDen);
 }
 
@@ -5792,7 +5594,7 @@ void CreateTargetMode2(IDDCX_TARGET_MODE2 &Mode, UINT Width, UINT Height, UINT V
 			  << ", VSyncDen: " << VSyncDen;
 	vddlog("d", logStream.str().c_str());
 
-	Mode.Size = sizeof(Mode);
+	ZAKO_IDDCX_STRUCT_INIT(Mode, IDDCX_TARGET_MODE2);
 
 	if (ColourFormat == L"RGB")
 	{
@@ -6069,7 +5871,7 @@ _Use_decl_annotations_
 		logStream << "Writing monitor modes to output buffer:";
 		for (DWORD ModeIndex = 0; ModeIndex < localModes.size(); ModeIndex++)
 		{
-			pInArgs->pMonitorModes[ModeIndex].Size = sizeof(IDDCX_MONITOR_MODE2);
+			ZAKO_IDDCX_STRUCT_INIT(pInArgs->pMonitorModes[ModeIndex], IDDCX_MONITOR_MODE2);
 			pInArgs->pMonitorModes[ModeIndex].Origin = IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR;
 			pInArgs->pMonitorModes[ModeIndex].MonitorVideoSignalInfo = s_KnownMonitorModes2[ModeIndex];
 

--- a/Virtual Display Driver (HDR)/vdd_settings.xml
+++ b/Virtual Display Driver (HDR)/vdd_settings.xml
@@ -45,7 +45,6 @@
         
     </resolutions>
 	<logging>
-		<SendLogsThroughPipe>true</SendLogsThroughPipe> <!-- Can only send logs through pipe if logging is enabled-->
 		<logging>false</logging>
 		<!-- DEBUG LOGGING FOR EXPERTS ONLY!-->
 		<debuglogging>false</debuglogging>


### PR DESCRIPTION
## 改了啥呀

- 以 `v0.15.1` 为保守的 Win10 兼容基线，保留 Legacy EDID 与 `SETMODES`
- 移除驱动运行时命名管道、阻塞线程及对应配置，只保留 IOCTL 控制通道
- 将共享 IOCTL 协议头与 Sunshine 当前版本对齐
- 控制接口注册失败时终止设备创建，避免留下“驱动已安装但控制接口不可用”的半残状态
- 使用 `IDD_STRUCTURE_SIZE` 初始化 IddCx 结构，兼容 Win10 较旧的运行时结构大小
- 复用仓库已有修复，将维护线 CI 固定到 VS2022 与对应 WDK task

## 为啥要改

Sunshine 已经只通过 IOCTL 控制 ZakoVDD，但原先固定给 Win10 的旧驱动不提供这个接口，于是会出现 `VDD IOCTL interface missing`。直接把 v0.17.0 全量塞给 Win10 又会顺带引入帧通道、光标导出等新能力，风险范围太大。

所以这次走一条很克制的维护线：只补 Sunshine 必需的控制能力和 Win10 结构兼容，不把杂鱼新功能偷偷带进兼容包。

## 影响

- PR 目标是独立的 `win10` 维护分支，不改变最新驱动的 `main`
- 驱动包安装与命令语法不变
- 未实现的 frame-channel IOCTL 会继续返回 `STATUS_NOT_SUPPORTED`，Sunshine 按兼容路径处理

## 验证

- VS2022/WDK Release x64 构建通过，0 error
- Universal API Validator 通过
- Inf2Cat `/os:10_x64` 通过，0 error / 0 warning
- 产物包含控制接口 GUID 与 `SETMODES`
- 产物不包含 `ZakoVDDPipe`
- Win10 Legacy EDID 字节保持一致
- Sunshine VDD payload selection smoke tests 全部通过
- 模拟 Windows build `19045`，实际新产物正确解析到 `scripts\driver\win10`
- [GitHub Actions 手动构建、签名与 artifact 上传全部通过](https://github.com/qiin2333/zako-vdd/actions/runs/30144607822)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frame-channel capability discovery and channel-opening support.
  * Added versioned frame-channel negotiation and handle management.
* **Bug Fixes**
  * Improved driver setup verification and installation reliability.
  * Added fallback locations for log files when the configured directory is unavailable.
  * Standardized driver structure initialization for improved stability.
* **Refactor**
  * Removed legacy named-pipe communication in favor of device control requests.
  * Updated build workflows to support the `main` branch and a fixed Windows build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->