### PR TITLE
fix(ci): route Win10 VDD release updates

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -281,4 +281,4 @@ jobs:
           token: ${{ secrets.SUNSHINE_DISPATCH_TOKEN }}
           repository: qiin2333/foundation-sunshine
           event-type: driver-release
-          client-payload: '{"component": "vdd", "version": "${{ github.ref_name }}"}'
+          client-payload: '{"component": "vdd-win10", "version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## 改了啥呀

- Win10 维护线发布后发送 `component=vdd-win10`
- 不再把 Win10 维护版本伪装成普通 `vdd` 更新

## 为啥要改

`v0.15.2` 发布时旧 payload 触发了 Sunshine 的 latest VDD 更新，把 `v0.17.0` 错误降级成 `v0.15.2`。Win10 与 latest 是两条独立发布线，通知也必须明确分流，别让杂鱼自动化再串台啦。

## 验证

- workflow YAML 解析通过
- Sunshine PR #842 已加入对应的 `vdd-win10` 路由
- 改动仅涉及一个 repository-dispatch payload
