### PR TITLE
fix(iddcx): preserve monitor ownership during teardown

### DIFF
--- a/ZakoVDD/Device/IndirectDeviceContext.cpp
+++ b/ZakoVDD/Device/IndirectDeviceContext.cpp
@@ -56,26 +56,21 @@ IndirectDeviceContext::~IndirectDeviceContext()
 	m_MouseEvents.clear();
 	VDD_LOG_DEBUG("Hardware cursor event handles cleaned up in destructor");
 
-	for (auto &pair : m_Monitors)
 	{
-		try
+		std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+		if (!m_Monitors.empty())
 		{
-			if (pair.second != nullptr)
-			{
-				VDD_LOG_DEBUG_STREAM("Cleaning up monitor " << pair.first << " in destructor");
-				WdfObjectDelete(pair.second);
-			}
+			// An arrived IDDCX_MONITOR is owned by IddCx and must only be
+			// explicitly removed with IddCxMonitorDeparture. Device cleanup
+			// already attempts that through DestroyAllMonitors. If departure
+			// failed, leave the WDF objects to the framework's parent teardown
+			// instead of deleting them directly from this context destructor.
+			VDD_LOG_WARNING_STREAM(m_Monitors.size()
+			                       << " monitor(s) remain during context destruction; "
+			                          "releasing local references without deleting IddCx objects");
 		}
-		catch (const exception &e)
-		{
-			VDD_LOG_ERROR_STREAM("Exception while cleaning monitor in destructor: " << e.what());
-		}
-		catch (...)
-		{
-			VDD_LOG_ERROR("Unknown exception while cleaning monitor in destructor");
-		}
+		m_Monitors.clear();
 	}
-	m_Monitors.clear();
 
 	VDD_LOG_DEBUG("IndirectDeviceContext cleanup completed.");
 }


### PR DESCRIPTION
## 改了啥呀

- 移除 `IndirectDeviceContext` 析构函数中对已完成 Arrival 的 `IDDCX_MONITOR` 直接调用 `WdfObjectDelete` 的路径。
- 正常清理继续通过 `DestroyAllMonitors()` / `IddCxMonitorDeparture()` 完成。
- 如果 Departure 重试后仍失败，析构只记录告警并释放本地引用，让 WDF 父对象 teardown 接管对象销毁。

## 为啥要改

已完成 Arrival 的 monitor 归 IddCx 管理，显式移除必须走 `IddCxMonitorDeparture()`。之前 Departure 失败后，析构还会直接删除同一个对象，可能在设备卸载、驱动重载或 UMDF host teardown 时触发重复删除或对象所有权冲突。这个坏状态还是乖乖交回 IddCx/WDF 收拾吧，杂鱼析构函数不许越权啦。

## 用户影响

降低虚拟显示器销毁、设备重启和驱动卸载期间发生 HostTimeout、崩溃或残留异常状态的风险。未修改尚未确认的 Windows 26H2 CCD/`SetDisplayConfig` 行为。

## 验证

- `MSBuild ZakoVDD.sln /m:1 /t:Build /p:Configuration=Release /p:Platform=x64 /p:SkipPackageVerification=true /v:minimal`
  - Release x64 构建成功
  - Signability test、CAT 生成和签名成功
  - 0 errors，0 warnings
- `git diff --check` 通过
- 静态复查确认剩余 `WdfObjectDelete` 仅用于 Arrival 失败前的 monitor 或 swap-chain 对象

## 环境备注

本机 WDK 10.0.26100.0 的 `x86/InfVerif.dll` 依赖缺失，因此成功构建跳过了 DPVerifier package verification；后续 Signability、CAT 生成和签名步骤均正常通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化设备上下文销毁时的监视器资源清理流程。
  * 避免重复释放由系统框架管理的监视器对象，提升设备退出和资源回收的稳定性。
  * 增加异常残留监视器的告警提示，便于发现潜在的资源清理问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->