### PR TITLE
fix(cursor): make VDD cursor export reliable

### DIFF
--- a/Common/Include/vdd_cursor_shared.h
+++ b/Common/Include/vdd_cursor_shared.h
@@ -9,6 +9,11 @@
 #define VDD_CURSOR_MAX_HEIGHT 256u
 #define VDD_CURSOR_MAX_BYTES (VDD_CURSOR_MAX_WIDTH * VDD_CURSOR_MAX_HEIGHT * 4u)
 
+/* DXGI-compatible shape types consumed by the capture host. */
+#define VDD_CURSOR_SHAPE_MONOCHROME 0u
+#define VDD_CURSOR_SHAPE_COLOR 1u
+#define VDD_CURSOR_SHAPE_MASKED_COLOR 2u
+
 /*
  * Shared-memory cursor metadata followed immediately by ShapeBufferSize bytes
  * of cursor pixels. PublicationSequence is odd while the producer is writing

--- a/ZakoVDD/Config/DriverSettings.cpp
+++ b/ZakoVDD/Config/DriverSettings.cpp
@@ -123,9 +123,9 @@ void LoadDriverSettings()
 
 	// Cursor
 	hardwareCursor = EnabledQuery(L"HardwareCursorEnabled");
-	alphaCursorSupport = EnabledQuery(L"AlphaCursorSupport");
-	CursorMaxX = GetIntegerSetting(L"CursorMaxX");
-	CursorMaxY = GetIntegerSetting(L"CursorMaxY");
+	alphaCursorSupport = EnabledQuery(L"AlphaCursorSupport", true);
+	CursorMaxX = GetIntegerSetting(L"CursorMaxX", 128);
+	CursorMaxY = GetIntegerSetting(L"CursorMaxY", 128);
 
 	int xorCursorSupportLevelInt = GetIntegerSetting(L"XorCursorSupportLevel");
 	string xorCursorSupportLevelName;

--- a/ZakoVDD/Config/DriverSettings.cpp
+++ b/ZakoVDD/Config/DriverSettings.cpp
@@ -122,28 +122,35 @@ void LoadDriverSettings()
 	legacyNamedFrameChannel = EnabledQuery(L"LegacyNamedFrameChannel");
 
 	// Cursor
-	hardwareCursor = EnabledQuery(L"HardwareCursorEnabled");
-	alphaCursorSupport = EnabledQuery(L"AlphaCursorSupport", true);
-	CursorMaxX = GetIntegerSetting(L"CursorMaxX", 128);
-	CursorMaxY = GetIntegerSetting(L"CursorMaxY", 128);
+	const bool hardwareCursorValue = EnabledQuery(L"HardwareCursorEnabled");
+	const bool alphaCursorSupportValue = EnabledQuery(L"AlphaCursorSupport", true);
+	const int cursorMaxXValue = GetIntegerSetting(L"CursorMaxX", 128);
+	const int cursorMaxYValue = GetIntegerSetting(L"CursorMaxY", 128);
 
 	int xorCursorSupportLevelInt = GetIntegerSetting(L"XorCursorSupportLevel");
-	string xorCursorSupportLevelName;
+	IDDCX_XOR_CURSOR_SUPPORT xorCursorSupportLevelValue;
 
 	if (xorCursorSupportLevelInt < 0 || xorCursorSupportLevelInt > 3)
 	{
 		VDD_LOG_WARNING("Selected Xor Level unsupported, defaulting to IDDCX_XOR_CURSOR_SUPPORT_FULL");
-		XorCursorSupportLevel = IDDCX_XOR_CURSOR_SUPPORT_FULL;
+		xorCursorSupportLevelValue = IDDCX_XOR_CURSOR_SUPPORT_FULL;
 	}
 	else
 	{
-		XorCursorSupportLevel = static_cast<IDDCX_XOR_CURSOR_SUPPORT>(xorCursorSupportLevelInt);
+		xorCursorSupportLevelValue = static_cast<IDDCX_XOR_CURSOR_SUPPORT>(xorCursorSupportLevelInt);
 	}
 
-	xorCursorSupportLevelName = XorCursorSupportLevelToString(XorCursorSupportLevel);
+	{
+		lock_guard<mutex> cursorSettingsLock(g_CursorSettingsMutex);
+		hardwareCursor = hardwareCursorValue;
+		alphaCursorSupport = alphaCursorSupportValue;
+		CursorMaxX = cursorMaxXValue;
+		CursorMaxY = cursorMaxYValue;
+		XorCursorSupportLevel = xorCursorSupportLevelValue;
+	}
 
-	VDD_LOG_INFO(("Selected Xor Cursor Support Level: " + xorCursorSupportLevelName).c_str());
-	VDD_LOG_INFO((string("Hardware cursor runtime setting: ") + (hardwareCursor ? "enabled" : "disabled")).c_str());
+	VDD_LOG_INFO((string("Selected Xor Cursor Support Level: ") + XorCursorSupportLevelToString(xorCursorSupportLevelValue)).c_str());
+	VDD_LOG_INFO((string("Hardware cursor runtime setting: ") + (hardwareCursorValue ? "enabled" : "disabled")).c_str());
 	VDD_LOG_INFO((string("Legacy named frame-channel export: ") + (legacyNamedFrameChannel ? "enabled" : "disabled")).c_str());
 }
 

--- a/ZakoVDD/Config/DriverSettings.h
+++ b/ZakoVDD/Config/DriverSettings.h
@@ -2,8 +2,8 @@
 
 #include <string>
 
-bool EnabledQuery(const std::wstring& settingKey);
-int GetIntegerSetting(const std::wstring& settingKey);
+bool EnabledQuery(const std::wstring& settingKey, bool defaultValue = false);
+int GetIntegerSetting(const std::wstring& settingKey, int defaultValue = -1);
 std::wstring GetStringSetting(const std::wstring& settingKey);
 
 bool UpdateXmlToggleSetting(bool toggle, const wchar_t* variable);

--- a/ZakoVDD/Config/SettingsQuery.cpp
+++ b/ZakoVDD/Config/SettingsQuery.cpp
@@ -176,12 +176,12 @@ bool TryReadXmlText(const wstring &xmlName, wstring &value)
 }
 }
 
-bool EnabledQuery(const wstring &settingKey)
+bool EnabledQuery(const wstring &settingKey, bool defaultValue)
 {
 	const auto *settingNames = FindSettingNames(settingKey);
 	if (settingNames == nullptr)
 	{
-		return false;
+		return defaultValue;
 	}
 
 	const wstring &regName = settingNames->first;
@@ -198,6 +198,7 @@ bool EnabledQuery(const wstring &settingKey)
 		if (dwValue == 0)
 		{
 			LogQueries(VddLogLevel::Verbose, xmlName + L" - is disabled (value = 0).");
+			return false;
 		}
 	}
 	else
@@ -215,6 +216,7 @@ bool EnabledQuery(const wstring &settingKey)
 			if (registryValue == L"false" || registryValue == L"0")
 			{
 				LogQueries(VddLogLevel::Verbose, xmlName + L" - is disabled (string value).");
+				return false;
 			}
 		}
 		else
@@ -226,20 +228,25 @@ bool EnabledQuery(const wstring &settingKey)
 	wstring xmlValue;
 	if (!TryReadXmlText(xmlName, xmlValue))
 	{
-		return false;
+		return defaultValue;
 	}
 
-	bool xmlLoggingValue = (xmlValue == L"true");
+	if (xmlValue != L"true" && xmlValue != L"1" && xmlValue != L"false" && xmlValue != L"0")
+	{
+		return defaultValue;
+	}
+
+	bool xmlLoggingValue = (xmlValue == L"true" || xmlValue == L"1");
 	LogQueries(VddLogLevel::Info, xmlName + (xmlLoggingValue ? L" is enabled." : L" is disabled."));
 	return xmlLoggingValue;
 }
 
-int GetIntegerSetting(const wstring &settingKey)
+int GetIntegerSetting(const wstring &settingKey, int defaultValue)
 {
 	const auto *settingNames = FindSettingNames(settingKey);
 	if (settingNames == nullptr)
 	{
-		return -1;
+		return defaultValue;
 	}
 
 	const wstring &regName = settingNames->first;
@@ -271,7 +278,7 @@ int GetIntegerSetting(const wstring &settingKey)
 	wstring xmlValue;
 	if (!TryReadXmlText(xmlName, xmlValue))
 	{
-		return -1;
+		return defaultValue;
 	}
 
 	try
@@ -283,7 +290,7 @@ int GetIntegerSetting(const wstring &settingKey)
 	catch (const exception &)
 	{
 		LogQueries(VddLogLevel::Verbose, xmlName + L" - Failed to convert XML string value to integer.");
-		return -1;
+		return defaultValue;
 	}
 }
 

--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -182,11 +182,11 @@ void HandleVrrCommand(wchar_t *param)
 void HandleHardwareCursorCommand(wchar_t *param)
 {
 	bool enabled = false;
-	if (wcsncmp(param, L"true", 4) == 0)
+	if (wcscmp(param, L"true") == 0)
 	{
 		enabled = true;
 	}
-	else if (wcsncmp(param, L"false", 5) != 0)
+	else if (wcscmp(param, L"false") != 0)
 	{
 		VDD_LOG_WARNING("HARDWARECURSOR requires true or false");
 		return;
@@ -214,15 +214,16 @@ void HandleHardwareCursorCommand(wchar_t *param)
 	// the next AssignSwapChain call applies the new capability. Re-registering
 	// the adapter here fails with STATUS_ALREADY_REGISTERED.
 	LoadDriverSettings();
-	const bool hadActiveMonitor = pContext->pContext->HasActiveMonitor();
-	const int recreated = pContext->pContext->RecreateAllMonitors();
-	if (hadActiveMonitor && recreated == 0)
+	const auto recreation = pContext->pContext->RecreateAllMonitors();
+	if (recreation.recreated != recreation.expected)
 	{
-		VDD_LOG_ERROR("Hardware cursor setting updated, but active monitors could not be re-enumerated");
+		VDD_LOG_ERROR_STREAM("Hardware cursor setting updated, but only " << recreation.recreated
+		                     << "/" << recreation.expected << " active monitor(s) were re-enumerated");
 		return;
 	}
 
-	VDD_LOG_INFO_STREAM("Hardware cursor runtime refresh completed; re-enumerated " << recreated << " monitor(s)");
+	VDD_LOG_INFO_STREAM("Hardware cursor runtime refresh completed; re-enumerated "
+	                    << recreation.recreated << " monitor(s)");
 }
 
 void HandleD3DDeviceGpuCommand(wchar_t *)

--- a/ZakoVDD/Control/CommandHandlers.cpp
+++ b/ZakoVDD/Control/CommandHandlers.cpp
@@ -181,7 +181,48 @@ void HandleVrrCommand(wchar_t *param)
 
 void HandleHardwareCursorCommand(wchar_t *param)
 {
-	ToggleSetting(param, L"HardwareCursor", "Hardware Cursor Enabled", "Hardware Cursor Disabled");
+	bool enabled = false;
+	if (wcsncmp(param, L"true", 4) == 0)
+	{
+		enabled = true;
+	}
+	else if (wcsncmp(param, L"false", 5) != 0)
+	{
+		VDD_LOG_WARNING("HARDWARECURSOR requires true or false");
+		return;
+	}
+
+	UpdateXmlToggleSetting(enabled, L"HardwareCursor");
+	VDD_LOG_INFO(enabled ? "Hardware Cursor Enabled" : "Hardware Cursor Disabled");
+
+	if (g_GlobalDevice == nullptr)
+	{
+		VDD_LOG_ERROR("Global device not available for hardware cursor refresh");
+		return;
+	}
+
+	lock_guard<mutex> lock(g_Mutex);
+	auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
+	if (!pContext || !pContext->pContext)
+	{
+		VDD_LOG_ERROR("Invalid device context for hardware cursor refresh");
+		return;
+	}
+
+	// Hardware-cursor capabilities are bound to a monitor's swapchain. Refresh
+	// the runtime setting, then re-enumerate monitors on the existing adapter so
+	// the next AssignSwapChain call applies the new capability. Re-registering
+	// the adapter here fails with STATUS_ALREADY_REGISTERED.
+	LoadDriverSettings();
+	const bool hadActiveMonitor = pContext->pContext->HasActiveMonitor();
+	const int recreated = pContext->pContext->RecreateAllMonitors();
+	if (hadActiveMonitor && recreated == 0)
+	{
+		VDD_LOG_ERROR("Hardware cursor setting updated, but active monitors could not be re-enumerated");
+		return;
+	}
+
+	VDD_LOG_INFO_STREAM("Hardware cursor runtime refresh completed; re-enumerated " << recreated << " monitor(s)");
 }
 
 void HandleD3DDeviceGpuCommand(wchar_t *)

--- a/ZakoVDD/Core/DriverState.cpp
+++ b/ZakoVDD/Core/DriverState.cpp
@@ -2,6 +2,7 @@
 
 std::mutex g_Mutex;
 std::mutex g_DataMutex; // Protects monitorModes, display colour settings, numVirtualDisplays, gpuname
+std::mutex g_CursorSettingsMutex; // Publishes cursor capability fields as one snapshot
 WDFDEVICE g_GlobalDevice = nullptr;
 
 DriverOptions Options;

--- a/ZakoVDD/Core/DriverState.h
+++ b/ZakoVDD/Core/DriverState.h
@@ -11,6 +11,7 @@
 
 extern std::mutex g_Mutex;
 extern std::mutex g_DataMutex;
+extern std::mutex g_CursorSettingsMutex;
 extern WDFDEVICE g_GlobalDevice;
 
 extern DriverOptions Options;

--- a/ZakoVDD/Device/IndirectDeviceContext.h
+++ b/ZakoVDD/Device/IndirectDeviceContext.h
@@ -38,6 +38,7 @@ namespace Microsoft
 			bool HasMonitor(unsigned int index) const { std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex); return m_Monitors.count(index) > 0; }
 			void UnassignAllSwapChains();
 			void DestroyAllMonitors();
+			int RecreateAllMonitors();
 
 			int RefreshMonitorModes(bool refreshMonitorDescription);
 

--- a/ZakoVDD/Device/IndirectDeviceContext.h
+++ b/ZakoVDD/Device/IndirectDeviceContext.h
@@ -3,6 +3,7 @@
 #include "..\Driver.h"
 #include "..\Rendering\SwapChainProcessor.h"
 
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -15,6 +16,12 @@ namespace Microsoft
 		class IndirectDeviceContext
 		{
 		public:
+			struct MonitorRecreationResult
+			{
+				std::size_t expected = 0;
+				std::size_t recreated = 0;
+			};
+
 			IndirectDeviceContext(_In_ WDFDEVICE WdfDevice);
 			virtual ~IndirectDeviceContext();
 
@@ -38,7 +45,7 @@ namespace Microsoft
 			bool HasMonitor(unsigned int index) const { std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex); return m_Monitors.count(index) > 0; }
 			void UnassignAllSwapChains();
 			void DestroyAllMonitors();
-			int RecreateAllMonitors();
+			MonitorRecreationResult RecreateAllMonitors();
 
 			int RefreshMonitorModes(bool refreshMonitorDescription);
 

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -367,7 +367,7 @@ void IndirectDeviceContext::DestroyAllMonitors()
 	}
 }
 
-int IndirectDeviceContext::RecreateAllMonitors()
+IndirectDeviceContext::MonitorRecreationResult IndirectDeviceContext::RecreateAllMonitors()
 {
 	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
 
@@ -378,18 +378,18 @@ int IndirectDeviceContext::RecreateAllMonitors()
 		monitorIndices.push_back(pair.first);
 	}
 
-	int recreated = 0;
+	MonitorRecreationResult result = {monitorIndices.size(), 0};
 	for (unsigned int index : monitorIndices)
 	{
 		if (RecreateMonitor(index))
 		{
-			++recreated;
+			++result.recreated;
 		}
 	}
 
-	VDD_LOG_INFO_STREAM("RecreateAllMonitors: re-enumerated " << recreated << "/"
-	                    << monitorIndices.size() << " monitor(s)");
-	return recreated;
+	VDD_LOG_INFO_STREAM("RecreateAllMonitors: re-enumerated " << result.recreated << "/"
+	                    << result.expected << " monitor(s)");
+	return result;
 }
 
 bool IndirectDeviceContext::RecreateMonitor(unsigned int index)

--- a/ZakoVDD/Device/MonitorLifecycle.cpp
+++ b/ZakoVDD/Device/MonitorLifecycle.cpp
@@ -367,6 +367,31 @@ void IndirectDeviceContext::DestroyAllMonitors()
 	}
 }
 
+int IndirectDeviceContext::RecreateAllMonitors()
+{
+	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+
+	vector<unsigned int> monitorIndices;
+	monitorIndices.reserve(m_MonitorCreationParams.size());
+	for (const auto &pair : m_MonitorCreationParams)
+	{
+		monitorIndices.push_back(pair.first);
+	}
+
+	int recreated = 0;
+	for (unsigned int index : monitorIndices)
+	{
+		if (RecreateMonitor(index))
+		{
+			++recreated;
+		}
+	}
+
+	VDD_LOG_INFO_STREAM("RecreateAllMonitors: re-enumerated " << recreated << "/"
+	                    << monitorIndices.size() << " monitor(s)");
+	return recreated;
+}
+
 bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
 {
 	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);

--- a/ZakoVDD/Device/SwapChainLifecycle.cpp
+++ b/ZakoVDD/Device/SwapChainLifecycle.cpp
@@ -71,10 +71,14 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 
 			IDDCX_CURSOR_CAPS cursorInfo = {};
 			cursorInfo.Size = sizeof(cursorInfo);
-			cursorInfo.ColorXorCursorSupport = IDDCX_XOR_CURSOR_SUPPORT_FULL;
+			cursorInfo.ColorXorCursorSupport = XorCursorSupportLevel;
 			cursorInfo.AlphaCursorSupport = alphaCursorSupport;
 			cursorInfo.MaxX = CursorMaxX;
 			cursorInfo.MaxY = CursorMaxY;
+			VDD_LOG_INFO_STREAM("Setting up hardware cursor: MaxX=" << cursorInfo.MaxX
+			                    << ", MaxY=" << cursorInfo.MaxY
+			                    << ", alpha=" << cursorInfo.AlphaCursorSupport
+			                    << ", xor=" << cursorInfo.ColorXorCursorSupport);
 
 			IDARG_IN_SETUP_HWCURSOR hwCursor = {};
 			hwCursor.CursorInfo = cursorInfo;

--- a/ZakoVDD/Device/SwapChainLifecycle.cpp
+++ b/ZakoVDD/Device/SwapChainLifecycle.cpp
@@ -58,7 +58,21 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 		VDD_LOG_DEBUG("Cleaned up existing mouse event handle");
 	}
 
-	if (hardwareCursor)
+	bool hardwareCursorEnabled;
+	bool alphaCursorSupportEnabled;
+	int cursorMaxX;
+	int cursorMaxY;
+	IDDCX_XOR_CURSOR_SUPPORT xorCursorSupportLevel;
+	{
+		lock_guard<mutex> cursorSettingsLock(g_CursorSettingsMutex);
+		hardwareCursorEnabled = hardwareCursor;
+		alphaCursorSupportEnabled = alphaCursorSupport;
+		cursorMaxX = CursorMaxX;
+		cursorMaxY = CursorMaxY;
+		xorCursorSupportLevel = XorCursorSupportLevel;
+	}
+
+	if (hardwareCursorEnabled)
 	{
 		HANDLE hMouseEvent = CreateEventA(nullptr, false, false, nullptr);
 		if (!hMouseEvent)
@@ -71,10 +85,10 @@ void IndirectDeviceContext::AssignSwapChain(IDDCX_MONITOR Monitor, IDDCX_SWAPCHA
 
 			IDDCX_CURSOR_CAPS cursorInfo = {};
 			cursorInfo.Size = sizeof(cursorInfo);
-			cursorInfo.ColorXorCursorSupport = XorCursorSupportLevel;
-			cursorInfo.AlphaCursorSupport = alphaCursorSupport;
-			cursorInfo.MaxX = CursorMaxX;
-			cursorInfo.MaxY = CursorMaxY;
+			cursorInfo.ColorXorCursorSupport = xorCursorSupportLevel;
+			cursorInfo.AlphaCursorSupport = alphaCursorSupportEnabled;
+			cursorInfo.MaxX = cursorMaxX;
+			cursorInfo.MaxY = cursorMaxY;
 			VDD_LOG_INFO_STREAM("Setting up hardware cursor: MaxX=" << cursorInfo.MaxX
 			                    << ", MaxY=" << cursorInfo.MaxY
 			                    << ", alpha=" << cursorInfo.AlphaCursorSupport

--- a/ZakoVDD/Rendering/CursorExporter.cpp
+++ b/ZakoVDD/Rendering/CursorExporter.cpp
@@ -18,6 +18,22 @@ namespace
 
 static constexpr UINT32 DEFAULT_SDR_WHITE_LEVEL_NITS = 80u;
 
+constexpr UINT32 ToSharedCursorShapeType(IDDCX_CURSOR_SHAPE_TYPE type)
+{
+	switch (type)
+	{
+	case IDDCX_CURSOR_SHAPE_TYPE_ALPHA:
+		return VDD_CURSOR_SHAPE_COLOR;
+	case IDDCX_CURSOR_SHAPE_TYPE_MASKED_COLOR:
+		return VDD_CURSOR_SHAPE_MASKED_COLOR;
+	default:
+		return VDD_CURSOR_SHAPE_MONOCHROME;
+	}
+}
+
+static_assert(ToSharedCursorShapeType(IDDCX_CURSOR_SHAPE_TYPE_ALPHA) == VDD_CURSOR_SHAPE_COLOR);
+static_assert(ToSharedCursorShapeType(IDDCX_CURSOR_SHAPE_TYPE_MASKED_COLOR) == VDD_CURSOR_SHAPE_MASKED_COLOR);
+
 enum class CursorQueryApi
 {
 	Query1,
@@ -280,7 +296,7 @@ void CursorExporter::Run()
 		{
 			lastShapeId = queryResult.CursorShapeInfo.ShapeId;
 			m_CachedShape.ShapeId = queryResult.CursorShapeInfo.ShapeId;
-			m_CachedShape.Type = static_cast<UINT32>(queryResult.CursorShapeInfo.CursorType);
+			m_CachedShape.Type = ToSharedCursorShapeType(queryResult.CursorShapeInfo.CursorType);
 			m_CachedShape.Width = queryResult.CursorShapeInfo.Width;
 			m_CachedShape.Height = queryResult.CursorShapeInfo.Height;
 			m_CachedShape.Pitch = queryResult.CursorShapeInfo.Pitch;


### PR DESCRIPTION
## 改了啥呀

- 修改硬件光标配置后只刷新显示器，不再重载整个适配器
- 为旧版/稀疏配置补齐安全的 Alpha 与尺寸默认值，并严格保留显式关闭值
- 将 IDDCX 光标类型显式映射为宿主使用的 DXGI 兼容协议值
- 按配置上报 XOR 能力，并补充硬件光标能力日志

## 为啥

旧安装缺少新增配置项时，驱动会用无效尺寸调用 `IddCxMonitorSetupHardwareCursor()`；同时 IDDCX 与共享协议的枚举数值并不一致。结果就是看似启用了硬件光标，实际导出链路却悄悄断掉了，杂鱼配置文件也能稳定升级才算闭环嘛。

## 影响

改动仅覆盖 VDD 硬件光标初始化、运行时刷新和共享形态标记；共享内存布局保持不变。

## 验证

- MSBuild Release 构建通过（驱动版本 100.0.17.4）
- Inf2Cat signability 检查通过
- 本机安装驱动后，VDD → Sunshine → Moonlight 本地光标链路实测通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增强硬件光标支持，可根据配置应用单色、彩色及带掩码彩色光标。
  * 修改硬件光标设置后，可自动刷新现有显示器配置，无需重启应用。
  * 支持配置光标最大尺寸及 Alpha、XOR 能力。

* **问题修复**
  * 缺少或无效的设置现在会使用可靠的默认值。
  * 改进布尔值和整数配置的解析，提升配置兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->