### PR TITLE
fix(win10): re-enumerate monitors when SETMODES changes the mode list

### DIFF
--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -2035,9 +2035,9 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 	// Replaces the live monitorModes list (in-memory only; not persisted to XML)
 	// and immediately republishes it to all live monitors via
 	// RefreshMonitorModes(). Allows clients (Sunshine etc.) to negotiate an
-	// exact session resolution. When the list actually changes the monitors are
-	// re-enumerated so Windows reparses the monitor description; an unchanged
-	// list takes the cheap no-departure path.
+	// exact session resolution. Only a list that actually changed triggers a
+	// re-enumeration so Windows reparses the monitor description; an unchanged
+	// list is a no-op.
 	auto handleSetModes = [](HANDLE, wchar_t *param)
 	{
 		if (param == nullptr || *param == L'\0')
@@ -2088,29 +2088,29 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 		   << (modeListChanged ? "true" : "false");
 		vddlog("i", ss.str().c_str());
 
-		// Push to live monitors. A changed mode list has to go out as a full
-		// re-enumeration: Windows will not accept a target mode that is absent
-		// from the monitor description it has cached, so a mode-only update
-		// would silently leave the new resolution unusable (and is unavailable
-		// altogether on Win10, where IddCxMonitorUpdateModes2 does not exist).
+		// Push to live monitors only when the list actually changed. A changed
+		// mode list has to go out as a full re-enumeration: Windows will not
+		// accept a target mode that is absent from the monitor description it
+		// has cached, so a mode-only update would silently leave the new
+		// resolution unusable (and is unavailable altogether on Win10, where
+		// IddCxMonitorUpdateModes2 does not exist). An unchanged list needs no
+		// push at all.
+		if (!modeListChanged)
+		{
+			vddlog("d", "SETMODES: mode list unchanged, nothing to publish");
+			return;
+		}
+
 		if (g_GlobalDevice != nullptr)
 		{
 			lock_guard<mutex> lock(g_Mutex);
 			auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
 			if (pContext && pContext->pContext)
 			{
-				int n = pContext->pContext->RefreshMonitorModes(modeListChanged);
+				int n = pContext->pContext->RefreshMonitorModes(true);
 				stringstream s2;
-				if (n < 0)
-				{
-					s2 << "SETMODES: mode push unavailable on this OS (IddCxMonitorUpdateModes2 missing)";
-					vddlog("w", s2.str().c_str());
-				}
-				else
-				{
-					s2 << "SETMODES: pushed to " << n << " live monitor(s)";
-					vddlog("i", s2.str().c_str());
-				}
+				s2 << "SETMODES: re-enumerated " << n << " monitor(s)";
+				vddlog("i", s2.str().c_str());
 			}
 		}
 	};
@@ -4814,6 +4814,11 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		m_MonitorGuids.erase(index);
 	}
 
+	// From here on this index is being rebuilt, so any arrival recorded for a
+	// previous incarnation no longer applies. Re-set only once the OS has
+	// actually accepted the new arrival below.
+	m_ArrivedMonitors.erase(index);
+
 	IDDCX_MONITOR_INFO MonitorInfo = {};
 	ZAKO_IDDCX_STRUCT_INIT(MonitorInfo, IDDCX_MONITOR_INFO);
 	MonitorInfo.MonitorType = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI;
@@ -4918,6 +4923,7 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		Status = IddCxMonitorArrival(newMonitor, &ArrivalOut);
 		if (NT_SUCCESS(Status))
 		{
+			m_ArrivedMonitors.insert(index);
 			vddlog("d", "Monitor arrival successfully reported.");
 		}
 		else
@@ -5066,6 +5072,7 @@ bool IndirectDeviceContext::DestroyMonitor(unsigned int index)
 
 	m_Monitors.erase(monIt);
 	m_MonitorCreationParams.erase(index);
+	m_ArrivedMonitors.erase(index);
 
 	logStream.str("");
 	logStream << "Monitor departed successfully (Index: " << index << ")";
@@ -5401,7 +5408,10 @@ bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
 		params.widthCm,
 		params.heightCm);
 
-	const bool recreated = m_Monitors.count(index) > 0;
+	// A handle in m_Monitors only means IddCxMonitorCreate succeeded; the
+	// arrival that follows can still fail, and that is precisely the case this
+	// whole path exists to repair. Judge success on the arrival instead.
+	const bool recreated = m_ArrivedMonitors.count(index) > 0;
 	if (!recreated)
 	{
 		// Preserve the parameters so a later forced refresh can retry this

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -2023,17 +2023,21 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 			vddlog("e", "REFRESHMODES: invalid device context");
 			return;
 		}
-		int n = pContext->pContext->RefreshMonitorModes();
+		// REFRESHMODES is an explicit request to republish the monitor
+		// description, so always take the re-enumeration path.
+		int n = pContext->pContext->RefreshMonitorModes(true);
 		stringstream ss;
-		ss << "REFRESHMODES: refreshed " << n << " monitor(s) without departure";
+		ss << "REFRESHMODES: re-enumerated " << n << " monitor(s)";
 		vddlog("i", ss.str().c_str());
 	};
 
 	// SETMODES <W>x<H>x<R>[,<W>x<H>x<R>...]
 	// Replaces the live monitorModes list (in-memory only; not persisted to XML)
-	// and immediately pushes it to all live monitors via RefreshMonitorModes().
-	// Allows clients (Sunshine etc.) to negotiate exact session resolution
-	// without triggering monitor departure / DWM window rearrangement.
+	// and immediately republishes it to all live monitors via
+	// RefreshMonitorModes(). Allows clients (Sunshine etc.) to negotiate an
+	// exact session resolution. When the list actually changes the monitors are
+	// re-enumerated so Windows reparses the monitor description; an unchanged
+	// list takes the cheap no-departure path.
 	auto handleSetModes = [](HANDLE, wchar_t *param)
 	{
 		if (param == nullptr || *param == L'\0')
@@ -2073,25 +2077,40 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 			return;
 		}
 
+		bool modeListChanged = true;
 		{
 			lock_guard<mutex> dataLock(g_DataMutex);
+			modeListChanged = (monitorModes != parsed);
 			monitorModes = parsed;
 		}
 		stringstream ss;
-		ss << "SETMODES: applied " << parsed.size() << " modes (in-memory only)";
+		ss << "SETMODES: applied " << parsed.size() << " modes (in-memory only), modeListChanged="
+		   << (modeListChanged ? "true" : "false");
 		vddlog("i", ss.str().c_str());
 
-		// Push to live monitors without departure
+		// Push to live monitors. A changed mode list has to go out as a full
+		// re-enumeration: Windows will not accept a target mode that is absent
+		// from the monitor description it has cached, so a mode-only update
+		// would silently leave the new resolution unusable (and is unavailable
+		// altogether on Win10, where IddCxMonitorUpdateModes2 does not exist).
 		if (g_GlobalDevice != nullptr)
 		{
 			lock_guard<mutex> lock(g_Mutex);
 			auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(g_GlobalDevice);
 			if (pContext && pContext->pContext)
 			{
-				int n = pContext->pContext->RefreshMonitorModes();
+				int n = pContext->pContext->RefreshMonitorModes(modeListChanged);
 				stringstream s2;
-				s2 << "SETMODES: pushed to " << n << " live monitor(s)";
-				vddlog("i", s2.str().c_str());
+				if (n < 0)
+				{
+					s2 << "SETMODES: mode push unavailable on this OS (IddCxMonitorUpdateModes2 missing)";
+					vddlog("w", s2.str().c_str());
+				}
+				else
+				{
+					s2 << "SETMODES: pushed to " << n << " live monitor(s)";
+					vddlog("i", s2.str().c_str());
+				}
 			}
 		}
 	};
@@ -4860,6 +4879,18 @@ void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClien
 		// Store in monitors map
 		m_Monitors[index] = newMonitor;
 
+		// Remember exactly how this monitor was built so RecreateMonitor can
+		// replay the same arrival when the monitor description has to be
+		// republished (see RefreshMonitorModes).
+		m_MonitorCreationParams[index] = {
+			pClientGuid != nullptr,
+			pClientGuid != nullptr ? *pClientGuid : GUID{},
+			maxNits,
+			minNits,
+			maxFALL,
+			widthCm,
+			heightCm};
+
 		// Store HDR luminance settings for this monitor
 		{
 			lock_guard<mutex> hdrLock(s_HdrSettingsMutex);
@@ -5034,6 +5065,7 @@ bool IndirectDeviceContext::DestroyMonitor(unsigned int index)
 	}
 
 	m_Monitors.erase(monIt);
+	m_MonitorCreationParams.erase(index);
 
 	logStream.str("");
 	logStream << "Monitor departed successfully (Index: " << index << ")";
@@ -5328,25 +5360,68 @@ void IndirectDeviceContext::DestroyAllMonitors()
 	}
 }
 
-int IndirectDeviceContext::RefreshMonitorModes()
+bool IndirectDeviceContext::RecreateMonitor(unsigned int index)
+{
+	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+
+	auto paramsIt = m_MonitorCreationParams.find(index);
+	if (paramsIt == m_MonitorCreationParams.end())
+	{
+		stringstream ss;
+		ss << "RecreateMonitor: creation parameters missing for monitor index=" << index;
+		vddlog("e", ss.str().c_str());
+		return false;
+	}
+
+	// Copy before DestroyMonitor erases the map entry.
+	const MonitorCreationParams params = paramsIt->second;
+
+	{
+		stringstream ss;
+		ss << "RecreateMonitor: re-enumerating monitor index=" << index
+		   << " so Windows reparses its monitor description";
+		vddlog("i", ss.str().c_str());
+	}
+
+	if (!DestroyMonitor(index))
+	{
+		stringstream ss;
+		ss << "RecreateMonitor: departure failed for monitor index=" << index;
+		vddlog("e", ss.str().c_str());
+		return false;
+	}
+	Sleep(100);
+
+	const GUID *pClientGuid = params.hasClientGuid ? &params.clientGuid : nullptr;
+	CreateMonitor(index,
+		pClientGuid,
+		params.maxNits,
+		params.minNits,
+		params.maxFALL,
+		params.widthCm,
+		params.heightCm);
+
+	const bool recreated = m_Monitors.count(index) > 0;
+	if (!recreated)
+	{
+		// Preserve the parameters so a later forced refresh can retry this
+		// monitor instead of losing its configuration permanently.
+		m_MonitorCreationParams[index] = params;
+		stringstream ss;
+		ss << "RecreateMonitor: failed to re-enumerate monitor index=" << index;
+		vddlog("e", ss.str().c_str());
+	}
+	return recreated;
+}
+
+int IndirectDeviceContext::RefreshMonitorModes(bool refreshMonitorDescription)
 {
 	// Forward declaration: defined later in this TU.
 	void CreateTargetMode2(IDDCX_TARGET_MODE2 & Mode, UINT Width, UINT Height, UINT VSyncNum, UINT VSyncDen);
 
-	// Push the current monitorModes snapshot to all live IDDCX_MONITOR objects
-	// via IddCxMonitorUpdateModes2. This avoids the DWM window rearrangement
-	// triggered by full monitor departure + arrival when only the mode list
-	// (resolution / refresh rate set) changes.
-	//
-	// Returns: number of monitors successfully refreshed, or -1 if the IddCx
-	// runtime does not export IddCxMonitorUpdateModes2 (older OS / SDK).
-	if (!IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2))
-	{
-		vddlog("w", "RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS");
-		return -1;
-	}
-
-	// Snapshot mode list under data lock and rebuild s_KnownMonitorModes2
+	// Snapshot mode list under data lock and rebuild s_KnownMonitorModes2 so
+	// both paths below (and any subsequent monitor arrival) observe the same
+	// mode set.
 	vector<tuple<int, int, int, int>> localModes;
 	{
 		lock_guard<mutex> dataLock(g_DataMutex);
@@ -5368,6 +5443,50 @@ int IndirectDeviceContext::RefreshMonitorModes()
 		return 0;
 	}
 
+	int refreshed = 0;
+	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
+
+	if (refreshMonitorDescription)
+	{
+		// Updating target modes cannot add a mode that is absent from the
+		// monitor-description list cached by Windows, so a changed mode list
+		// has to go out as a full departure + arrival. This path carries no
+		// IddCx version requirement, which is what makes SETMODES work on
+		// Win10 where IddCxMonitorUpdateModes2 is unavailable.
+		//
+		// Collect indices first: RecreateMonitor -> DestroyMonitor mutates
+		// m_MonitorCreationParams and would invalidate an iterator over it.
+		vector<unsigned int> monitorIndices;
+		monitorIndices.reserve(m_MonitorCreationParams.size());
+		for (const auto &pair : m_MonitorCreationParams)
+		{
+			monitorIndices.push_back(pair.first);
+		}
+
+		for (unsigned int index : monitorIndices)
+		{
+			if (RecreateMonitor(index))
+			{
+				++refreshed;
+			}
+		}
+
+		stringstream summary;
+		summary << "RefreshMonitorModes: re-enumerated " << refreshed << "/" << monitorIndices.size()
+		        << " monitor(s) with " << localModes.size() << " updated monitor-description modes";
+		vddlog("i", summary.str().c_str());
+		return refreshed;
+	}
+
+	// Lightweight path: push the mode list to live IDDCX_MONITOR objects via
+	// IddCxMonitorUpdateModes2, avoiding the DWM window rearrangement that
+	// follows departure + arrival. Requires IddCx >= 1.10.
+	if (!IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2))
+	{
+		vddlog("w", "RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS");
+		return -1;
+	}
+
 	// Build IDDCX_TARGET_MODE2 array once - same payload for every monitor.
 	vector<IDDCX_TARGET_MODE2> targetModes(localModes.size());
 	for (size_t i = 0; i < localModes.size(); ++i)
@@ -5380,8 +5499,6 @@ int IndirectDeviceContext::RefreshMonitorModes()
 	}
 
 	// Iterate live monitors under monitor lock and push the new mode list.
-	int refreshed = 0;
-	std::lock_guard<std::recursive_mutex> lock(m_monitorsMutex);
 	for (const auto &pair : m_Monitors)
 	{
 		IDDCX_MONITOR hMonitor = pair.second;

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
@@ -117,21 +117,51 @@ namespace Microsoft
             void UnassignAllSwapChains();
             void DestroyAllMonitors();
 
-            // Push current monitorModes to all live monitors via IddCxMonitorUpdateModes2,
-            // avoiding monitor departure/arrival (DWM window rearrangement).
-            // Returns number of monitors successfully refreshed; -1 if API unavailable.
-            int RefreshMonitorModes();
+            // Publish the current monitorModes list to all live monitors.
+            //
+            // refreshMonitorDescription == true re-enumerates every monitor
+            // (departure + arrival) so Windows reparses the monitor description.
+            // This is the only way to introduce a mode that is absent from the
+            // description Windows has cached, and it works on every IddCx
+            // version -- required on Win10, where IddCxMonitorUpdateModes2 does
+            // not exist.
+            //
+            // refreshMonitorDescription == false takes the lightweight
+            // IddCxMonitorUpdateModes2 path, which avoids the DWM window
+            // rearrangement that follows departure/arrival but can only
+            // reorder / drop modes already present in the description.
+            //
+            // Returns the number of monitors successfully refreshed, or -1 when
+            // the lightweight path was requested and the API is unavailable.
+            int RefreshMonitorModes(bool refreshMonitorDescription);
 
         private:
             bool WaitForSystemStabilization(int timeoutMs, const char *operation);
             bool ValidateMonitorState(const char *operation);
 
         protected:
+            // Everything CreateMonitor needs to rebuild a monitor identically.
+            // Retained per index so RecreateMonitor can replay the original
+            // arrival after a departure.
+            struct MonitorCreationParams
+            {
+                bool hasClientGuid = false;
+                GUID clientGuid{};
+                float maxNits = 1000.0f;
+                float minNits = 0.0001f;
+                float maxFALL = 0.0f;
+                float widthCm = 0.0f;
+                float heightCm = 0.0f;
+            };
+
+            bool RecreateMonitor(unsigned int index);
+
             WDFDEVICE m_WdfDevice;
             IDDCX_ADAPTER m_Adapter;
             mutable std::recursive_mutex m_monitorsMutex; // Protects m_Monitors, m_ProcessingThreads, m_MouseEvents
             std::map<unsigned int, IDDCX_MONITOR> m_Monitors;
             std::map<unsigned int, GUID> m_MonitorGuids; // Maps index to client GUID for EDID cleanup
+            std::map<unsigned int, MonitorCreationParams> m_MonitorCreationParams;
 
             std::map<IDDCX_MONITOR, DISPLAYCONFIG_VIDEO_SIGNAL_INFO> m_CommittedTargetModes;
             std::map<IDDCX_MONITOR, std::unique_ptr<SwapChainProcessor>> m_ProcessingThreads;

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <string>
 #include <map>
+#include <set>
 #include <mutex>
 
 #include "Trace.h"
@@ -158,10 +159,17 @@ namespace Microsoft
 
             WDFDEVICE m_WdfDevice;
             IDDCX_ADAPTER m_Adapter;
-            mutable std::recursive_mutex m_monitorsMutex; // Protects m_Monitors, m_ProcessingThreads, m_MouseEvents
+            // Protects m_Monitors, m_MonitorCreationParams, m_ArrivedMonitors,
+            // m_ProcessingThreads and m_MouseEvents
+            mutable std::recursive_mutex m_monitorsMutex;
             std::map<unsigned int, IDDCX_MONITOR> m_Monitors;
             std::map<unsigned int, GUID> m_MonitorGuids; // Maps index to client GUID for EDID cleanup
             std::map<unsigned int, MonitorCreationParams> m_MonitorCreationParams;
+            // Indices whose IddCxMonitorArrival succeeded. A monitor handle
+            // exists in m_Monitors from IddCxMonitorCreate onwards, including
+            // when the subsequent arrival fails, so handle presence alone does
+            // not mean the OS ever saw the monitor.
+            std::set<unsigned int> m_ArrivedMonitors;
 
             std::map<IDDCX_MONITOR, DISPLAYCONFIG_VIDEO_SIGNAL_INFO> m_CommittedTargetModes;
             std::map<IDDCX_MONITOR, std::unique_ptr<SwapChainProcessor>> m_ProcessingThreads;


### PR DESCRIPTION
## 问题

Win10 22H2 用户反馈 0.15.1 / 0.15.2 / 0.15.3 都创建不了显示器；0.14.3 正常。Sunshine 日志显示"创建显示器成功但枚举不到"。

## 根因

`v0.15.0`（PR #7）引入了 `SETMODES` 命令，它会替换内存中的 `monitorModes` 然后调用 `RefreshMonitorModes()` 把新模式推给已存在的 monitor。但 `win10` 分支上的 `RefreshMonitorModes()` **只有一条路径**——`IddCxMonitorUpdateModes2`，而这个 API 需要 **IddCx ≥ 1.10**，Win10 上不存在：

```cpp
int IndirectDeviceContext::RefreshMonitorModes()
{
    if (!IDD_IS_FUNCTION_AVAILABLE(IddCxMonitorUpdateModes2))
    {
        vddlog("w", "RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS");
        return -1;   // <-- Win10 在这里就返回了，什么都没做
    }
    ...
}
```

于是在 Win10 上：

1. Sunshine 发 `SETMODES <W>x<H>x<R>`
2. `handleSetModes` 换掉内存里的 `monitorModes`
3. `RefreshMonitorModes()` 第一句就返回 `-1`
4. Windows 缓存的 monitor description 从未更新
5. `IddCxMonitorArrival` 报告成功，但 Sunshine 要的模式不在 Windows 缓存的 description 里 → **显示器枚举不到**

而且 `IddCxMonitorUpdateModes2` 本身也只能重排/裁剪 description 里**已有**的模式，无法新增——所以即使在 Win11 上，模式列表真的变了时也应该走重建。`main` 分支有 `RecreateMonitor` 这条与 IddCx 版本无关的回退路径（这也是 Win11 + 0.17.2 上 SETMODES 正常的原因），`win10` 分支上 `RecreateMonitor` 和 `m_MonitorCreationParams` 出现次数为 **0**。

这同时解释了全部四个已知事实：0.14.3 正常（早于 SETMODES）、0.15.1/2/3 表现完全一致（自 v0.15.0 起都缺回退）、Win11 + 0.17.2 正常、以及 v0.15.3 的 departure ownership 修复无效（重建路径根本不可达）。

## 改动

从 `main` 分支移植重建路径：

- `Driver.h`
  - `RefreshMonitorModes()` → `RefreshMonitorModes(bool refreshMonitorDescription)`
  - 新增 `MonitorCreationParams` 结构与 `m_MonitorCreationParams` 映射，保存每个 monitor 的创建参数
  - 新增 `RecreateMonitor(unsigned int index)`
- `Driver.cpp`
  - `CreateMonitor` 里记录创建参数，`DestroyMonitor` 里清除
  - `RecreateMonitor`：departure → `Sleep(100)` → 用原参数 arrival，失败时保留参数以便后续重试
  - `RefreshMonitorModes`：把 `localModes` 快照和空列表检查**提到** `IDD_IS_FUNCTION_AVAILABLE` 之前；`refreshMonitorDescription == true` 时走重建分支并直接返回（无 IddCx 版本要求）
    - 重建前先把 index 拷进 `vector`，避免 `DestroyMonitor` 修改 `m_MonitorCreationParams` 导致迭代器失效
  - `handleSetModes` 计算 `modeListChanged`（新旧列表比较）并传入；`handleRefreshModes` 传 `true`
  - 顺带修掉 `SETMODES: pushed to -1 live monitor(s)` 这种把错误码当计数打印的日志，改成显式的 warning 分支

## 验证

⚠️ 本地无法编译验证（WDK/MSBuild 仅限 Windows），**CI 是第一道编译门禁，Win10 22H2 用户测试是功能门禁**。

请 Win10 22H2 用户装 CI 产物后：

1. 编辑 `C:\VirtualDisplayDriver\vdd_settings.xml`，把 `<logging>` 和 `<debuglogging>` 都改成 `true`
2. 启动 Sunshine 串流
3. 抓 `C:\VirtualDisplayDriver\Logs\log_<date>.txt`

修复前的特征日志：

```
[w] RefreshMonitorModes: IddCxMonitorUpdateModes2 not available on this OS
[i] SETMODES: pushed to -1 live monitor(s)
```

修复后应看到：

```
[i] SETMODES: applied N modes (in-memory only), modeListChanged=true
[i] RecreateMonitor: re-enumerating monitor index=0 so Windows reparses its monitor description
[i] RefreshMonitorModes: re-enumerated 1/1 monitor(s) with N updated monitor-description modes
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved virtual monitor mode refresh handling.
  * Automatically recreates monitors when display mode descriptions change.
  * Preserves monitor settings during recreation.
  * Supports full display refreshes across supported Windows versions.

* **Bug Fixes**
  * Improved tracking and recovery when monitor recreation fails.
  * Added clearer handling for systems that do not support advanced mode updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->