### PR TITLE
Fix Win10 monitor creation and use ZAK2333 hardware ID

### DIFF
--- a/.github/scripts/Test-Win10Compatibility.ps1
+++ b/.github/scripts/Test-Win10Compatibility.ps1
@@ -1,0 +1,79 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$driverPath = Join-Path $repoRoot 'Virtual Display Driver (HDR)\ZakoVDD\Driver.cpp'
+$source = Get-Content -LiteralPath $driverPath -Raw
+
+function Get-SourceSection {
+    param(
+        [Parameter(Mandatory)] [string] $StartMarker,
+        [Parameter(Mandatory)] [string] $EndMarker
+    )
+
+    $start = $source.IndexOf($StartMarker, [StringComparison]::Ordinal)
+    if ($start -lt 0) {
+        throw "Win10 compatibility guard could not find start marker: $StartMarker"
+    }
+
+    $end = $source.IndexOf($EndMarker, $start + $StartMarker.Length, [StringComparison]::Ordinal)
+    if ($end -lt 0) {
+        throw "Win10 compatibility guard could not find end marker: $EndMarker"
+    }
+
+    return $source.Substring($start, $end - $start)
+}
+
+$ioctlCallback = Get-SourceSection `
+    -StartMarker 'VOID VirtualDisplayDriverIoDeviceControl(' `
+    -EndMarker 'bool initpath()'
+
+if ($ioctlCallback -notmatch 'WdfWorkItemEnqueue\s*\(\s*workItem\s*\)') {
+    throw 'IOCTL_VDD_COMMAND must leave the IddCx callback stack through a WDF work item.'
+}
+
+if ($ioctlCallback -match 'DispatchVddCommandBuffer\s*\(') {
+    throw 'Do not dispatch VDD commands inline from VirtualDisplayDriverIoDeviceControl; Win10 IddCx rejects re-entrant monitor creation.'
+}
+
+$workItem = Get-SourceSection `
+    -StartMarker 'VOID VddCommandWorkItem(WDFWORKITEM WorkItem)' `
+    -EndMarker '// IddCx redirects every IRP_MJ_DEVICE_CONTROL'
+
+if ($workItem -notmatch 'DispatchVddCommandBuffer\s*\(\s*INVALID_HANDLE_VALUE\s*,\s*context->Buffer\s*\)') {
+    throw 'The WDF work item must dispatch the pending VDD command outside the IddCx callback stack.'
+}
+
+$edidIdentity = Get-SourceSection `
+    -StartMarker 'void modifyEdid(vector<BYTE> &edid)' `
+    -EndMarker '// Modify EDID serial number'
+
+$requiredAssignments = @(
+    'edid\[8\]\s*=\s*0x68',
+    'edid\[9\]\s*=\s*0x2b',
+    'edid\[10\]\s*=\s*0x33',
+    'edid\[11\]\s*=\s*0x23'
+)
+
+foreach ($assignment in $requiredAssignments) {
+    if ($edidIdentity -notmatch $assignment) {
+        throw "EDID identity must remain DISPLAY\ZAK2333; missing assignment: $assignment"
+    }
+}
+
+if ($source -match 'edid\[8\]\s*=\s*0x36[\s\S]*?edid\[9\]\s*=\s*0x94[\s\S]*?edid\[10\]\s*=\s*0x37[\s\S]*?edid\[11\]\s*=\s*0x13') {
+    throw 'Legacy DISPLAY\MTT1337 manufacturer spoof must not return.'
+}
+
+if ($env:GITHUB_REF -match '^refs/tags/v0\.15\.') {
+    & git -C $repoRoot fetch origin win10 --no-tags
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to fetch origin/win10 for release-lineage validation.'
+    }
+
+    & git -C $repoRoot merge-base --is-ancestor $env:GITHUB_SHA origin/win10
+    if ($LASTEXITCODE -ne 0) {
+        throw "Win10 release tag $env:GITHUB_REF_NAME must point to a commit contained in origin/win10."
+    }
+}
+
+Write-Host 'Win10 compatibility invariants passed: async IOCTL dispatch and DISPLAY\ZAK2333.'

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ on:
       - win10
     tags:
       - 'v*'
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches:
       - main
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Guard Win10 compatibility invariants
@@ -171,8 +171,9 @@ jobs:
         run: dir "Virtual Display Driver (HDR)\${{ matrix.platform }}\${{ matrix.configuration }}\ZakoVDD"
 
       - name: Sign driver with certificate
-        # Skip signing for PRs from forks to prevent secret exfiltration
-        if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
+        # PR code must never receive the production signing secret. Branch and
+        # tag builds still sign the release artifact after protected-branch CI.
+        if: github.event_name != 'pull_request'
         shell: pwsh
         env:
           SIGNING_CERT_PFX: ${{ secrets.SIGNING_CERT_PFX }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -30,6 +30,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Guard Win10 compatibility invariants
+        if: github.base_ref == 'win10' || github.ref_name == 'win10' || startsWith(github.ref, 'refs/tags/v0.15.')
+        shell: pwsh
+        run: ./.github/scripts/Test-Win10Compatibility.ps1
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,6 +13,7 @@ on:
     tags:
       - 'v*'
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches:
       - main
       - master

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -2159,6 +2159,51 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 	}
 }
 
+// IddCx invokes EvtIddCxDeviceIoControl on its own callback stack. Calling
+// monitor-management DDIs synchronously from that stack is re-entrant: on
+// Win10 IddCxMonitorCreate rejects it with STATUS_OPERATION_IN_PROGRESS
+// (0xC0000476). Keep the WDF request pending, dispatch the command from a
+// passive work item, and complete the request only after the command finishes.
+typedef struct _VDD_COMMAND_WORKITEM_CONTEXT
+{
+	WDFREQUEST Request;
+	wchar_t Buffer[2048];
+} VDD_COMMAND_WORKITEM_CONTEXT, *PVDD_COMMAND_WORKITEM_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VDD_COMMAND_WORKITEM_CONTEXT, VddGetCommandWorkItemContext);
+
+EVT_WDF_WORKITEM VddCommandWorkItem;
+
+_Use_decl_annotations_
+VOID VddCommandWorkItem(WDFWORKITEM WorkItem)
+{
+	auto *context = VddGetCommandWorkItemContext(WorkItem);
+	NTSTATUS completionStatus = STATUS_SUCCESS;
+
+	try
+	{
+		wstring bufferwstr(context->Buffer);
+		string bufferstr = WStringToString(bufferwstr);
+		vddlog("p", ("[IOCTL worker] " + bufferstr).c_str());
+		DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, context->Buffer);
+	}
+	catch (const std::exception &e)
+	{
+		stringstream errorStream;
+		errorStream << "Exception during asynchronous IOCTL command dispatch: " << e.what();
+		vddlog("e", errorStream.str().c_str());
+		completionStatus = STATUS_UNSUCCESSFUL;
+	}
+	catch (...)
+	{
+		vddlog("e", "Unknown exception during asynchronous IOCTL command dispatch");
+		completionStatus = STATUS_UNSUCCESSFUL;
+	}
+
+	WdfRequestCompleteWithInformation(context->Request, completionStatus, 0);
+	WdfObjectDelete(WorkItem);
+}
+
 // IddCx redirects every IRP_MJ_DEVICE_CONTROL into its own internal queue
 // before any default WDF queue ever sees it. The only way to receive a
 // custom IOCTL in an IddCx driver is through this callback registered via
@@ -2212,38 +2257,37 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			return;
 		}
 
-		// Copy into a writable, NUL-terminated local buffer. METHOD_BUFFERED
-		// already gives us a kernel-owned copy but the dispatch helpers
-		// expect a wchar_t array they can scribble on (e.g. swscanf_s).
-		wchar_t buffer[2048] = { 0 };
+		WDF_WORKITEM_CONFIG workItemConfig;
+		WDF_WORKITEM_CONFIG_INIT(&workItemConfig, VddCommandWorkItem);
+		workItemConfig.AutomaticSerialization = FALSE;
+
+		WDF_OBJECT_ATTRIBUTES workItemAttributes;
+		WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&workItemAttributes, VDD_COMMAND_WORKITEM_CONTEXT);
+		workItemAttributes.ParentObject = Device;
+
+		WDFWORKITEM workItem = nullptr;
+		status = WdfWorkItemCreate(&workItemConfig, &workItemAttributes, &workItem);
+		if (!NT_SUCCESS(status))
+		{
+			WdfRequestComplete(Request, status);
+			return;
+		}
+
+		auto *workContext = VddGetCommandWorkItemContext(workItem);
+		workContext->Request = Request;
+		RtlZeroMemory(workContext->Buffer, sizeof(workContext->Buffer));
+
+		// Copy into writable, NUL-terminated work-item storage. The request's
+		// METHOD_BUFFERED memory is not accessed after this callback returns.
 		size_t copyLen = inBufferLen;
-		if (copyLen > sizeof(buffer) - sizeof(wchar_t))
+		if (copyLen > sizeof(workContext->Buffer) - sizeof(wchar_t))
 		{
-			copyLen = sizeof(buffer) - sizeof(wchar_t);
+			copyLen = sizeof(workContext->Buffer) - sizeof(wchar_t);
 		}
-		RtlCopyMemory(buffer, pInBuffer, copyLen);
-		buffer[copyLen / sizeof(wchar_t)] = L'\0';
+		RtlCopyMemory(workContext->Buffer, pInBuffer, copyLen);
+		workContext->Buffer[copyLen / sizeof(wchar_t)] = L'\0';
 
-		try
-		{
-			wstring bufferwstr(buffer);
-			string bufferstr = WStringToString(bufferwstr);
-			vddlog("p", ("[IOCTL] " + bufferstr).c_str());
-
-			DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, buffer);
-		}
-		catch (const std::exception &e)
-		{
-			stringstream errorStream;
-			errorStream << "Exception during IOCTL command dispatch: " << e.what();
-			vddlog("e", errorStream.str().c_str());
-		}
-		catch (...)
-		{
-			vddlog("e", "Unknown exception during IOCTL command dispatch");
-		}
-
-		WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, 0);
+		WdfWorkItemEnqueue(workItem);
 		return;
 	}
 
@@ -3978,10 +4022,14 @@ void modifyEdid(vector<BYTE> &edid)
 		return;
 	}
 
-	edid[8] = 0x36;
-	edid[9] = 0x94;
-	edid[10] = 0x37;
-	edid[11] = 0x13;
+	// Keep the Win10 compatibility package aligned with v0.17.2: Windows
+	// exposes these EDID manufacturer/product bytes as DISPLAY\ZAK2333.
+	// Manufacturer "ZAK" is encoded as 0x682b; product 0x2333 is
+	// little-endian in the EDID base block.
+	edid[8] = 0x68;
+	edid[9] = 0x2b;
+	edid[10] = 0x33;
+	edid[11] = 0x23;
 }
 
 // Modify EDID serial number based on client GUID to ensure consistency

--- a/docs/win10-release-checklist.md
+++ b/docs/win10-release-checklist.md
@@ -26,7 +26,7 @@ An installed release package can outrank a locally built package even after `pnp
 
 ### Stacked PRs can bypass the intended workflow trigger
 
-The build workflow listens to pull requests whose base is `win10` (among other maintained branches). A PR stacked on another feature branch does not match that trigger. Before merge or release, retarget the final PR to `win10` and require its checks to complete.
+The build workflow listens to pull requests whose base is `win10` (among other maintained branches). A PR stacked on another feature branch does not match that trigger. Retargeting or marking a PR ready also uses event types outside GitHub's default pull-request trigger set. The workflow therefore listens to `edited` and `ready_for_review` explicitly. Before merge or release, retarget the final PR to `win10` and require its checks to complete.
 
 ## CI guard
 

--- a/docs/win10-release-checklist.md
+++ b/docs/win10-release-checklist.md
@@ -1,0 +1,63 @@
+# Win10 compatibility and release checklist
+
+This document records the failures found while validating the `v0.15.4` compatibility line on Windows 10 22H2 and defines the release gate for later `v0.15.x` builds.
+
+## What went wrong
+
+### The status code was initially misidentified
+
+`IddCxMonitorCreate` returned `0xC0000476`. The authoritative WDK `ntstatus.h` definition is `STATUS_OPERATION_IN_PROGRESS`, not a structure-size error. Always decode the exact NTSTATUS value from the WDK headers before changing IddCx structures.
+
+### A successful build did not model the Win10 IddCx runtime
+
+The driver compiled with a current WDK, but Windows 10 22H2 loaded IddCx 1.5.1. Windows 11 uses a newer runtime and accepted a call path that failed on Win10. WDK compilation proves API and ABI compatibility; it does not prove callback-ordering or re-entrancy behavior on an older runtime.
+
+### Changing the control transport changed the callback context
+
+`v0.14.3` handled commands on a named-pipe worker thread. The `v0.15.x` IOCTL transport initially dispatched monitor commands inline from `EvtIddCxDeviceIoControl`. Calling `IddCxMonitorCreate` on that IddCx callback stack returned `STATUS_OPERATION_IN_PROGRESS` on Win10. VDD commands must be dispatched from the WDF work item and the request completed after that worker finishes.
+
+### Display name and hardware ID are separate EDID fields
+
+The EDID text descriptor already contained `Zako HDR`, while the manufacturer and product bytes were still overwritten with the legacy `MTT1337` values. Win10 therefore enumerated `DISPLAY\MTT1337`. The compatibility line now uses the same identity as v0.17.2: manufacturer `ZAK`, product `0x2333`, exposed as `DISPLAY\ZAK2333`.
+
+### Windows driver ranking hid local test builds
+
+An installed release package can outrank a locally built package even after `pnputil /add-driver`. Before a compatibility test, remove the old OEM package and verify the active INF, DLL hash, driver version, and certificate. Do not infer that the new binary loaded from a successful install command alone.
+
+### Stacked PRs can bypass the intended workflow trigger
+
+The build workflow listens to pull requests whose base is `win10` (among other maintained branches). A PR stacked on another feature branch does not match that trigger. Before merge or release, retarget the final PR to `win10` and require its checks to complete.
+
+## CI guard
+
+`.github/scripts/Test-Win10Compatibility.ps1` runs for `win10`, PRs targeting `win10`, and `v0.15.*` tags. It rejects these known regressions:
+
+- inline command dispatch from `VirtualDisplayDriverIoDeviceControl`;
+- removal of the WDF work-item dispatch path;
+- restoration of the `DISPLAY\MTT1337` EDID bytes;
+- a `v0.15.*` tag whose commit is not contained in `origin/win10`.
+
+The guard is intentionally static. GitHub-hosted Windows runners do not reproduce the Win10 IddCx runtime, so this check cannot replace the VM smoke test.
+
+## Required VM smoke test
+
+Before creating a `v0.15.x` tag:
+
+1. Use Windows 10 Pro 22H2 build 19045 with test signing enabled and Secure Boot disabled for test-signed packages.
+2. Remove the previously installed ZakoVDD OEM package, then install the exact CI artifact being tested.
+3. Record the active INF version, DLL SHA-256, certificate, Windows build, and IddCx version.
+4. Send `CREATEMONITOR` and verify monitor creation plus arrival.
+5. Send `SETMODES 1920x1080x60,2560x1440x60` and verify re-enumeration.
+6. Assert that PnP reports `DISPLAY\ZAK2333`, the desktop mode is 1920x1080, and the shared texture reaches 1920x1080.
+7. Archive the driver log, test transcript, and `setupapi.dev.log`.
+
+The durable fully automated option is a self-hosted Win10 22H2 runner or lab machine. It should consume the unsigned/test-signed build artifact, run the steps above, upload the evidence, and be configured as a required environment/check before the release job. Until such a runner exists, release approval must include a link to the archived VM evidence.
+
+## Tag and release verification
+
+1. Confirm the release commit is contained in `origin/win10`.
+2. Create the tag only after the PR checks pass: `v0.15.<patch>`.
+3. Wait for both the build and release jobs.
+4. Download `zakovdd.zip` and verify it contains the DLL, INF, catalog, settings, and certificate.
+5. Verify the stamped INF version is `100.0.15.<patch>` and the catalog signature is valid.
+6. Record the release asset SHA-256 and confirm the Sunshine `vdd-win10` notification ran.

--- a/docs/win10-release-checklist.md
+++ b/docs/win10-release-checklist.md
@@ -28,6 +28,8 @@ An installed release package can outrank a locally built package even after `pnp
 
 The build workflow listens to pull requests whose base is `win10` (among other maintained branches). A PR stacked on another feature branch does not match that trigger. Retargeting or marking a PR ready also uses event types outside GitHub's default pull-request trigger set. The workflow therefore listens to `edited` and `ready_for_review` explicitly. Before merge or release, retarget the final PR to `win10` and require its checks to complete.
 
+PR builds use the standard `pull_request` event and never receive the production signing secret. The former `pull_request_target` configuration checked out and built PR-controlled code in a privileged base-repository context, which was both unreliable for the Win10 branch and an unnecessary secret-exposure risk. Signing is limited to protected branch and tag builds.
+
 ## CI guard
 
 `.github/scripts/Test-Win10Compatibility.ps1` runs for `win10`, PRs targeting `win10`, and `v0.15.*` tags. It rejects these known regressions:


### PR DESCRIPTION
## What changed

- Dispatch `IOCTL_VDD_COMMAND` commands from a WDF work item instead of invoking monitor-management IddCx DDIs inline from `EvtIddCxDeviceIoControl`.
- Keep the WDF request pending until asynchronous command dispatch completes.
- Align the compatibility driver's EDID manufacturer and product bytes with v0.17.2 so Windows enumerates the virtual monitor as `DISPLAY\ZAK2333` instead of the legacy `DISPLAY\MTT1337` identity.

PR #30 has landed, so this PR now targets `win10` directly and runs the maintained Win10 checks.

- Add a CI guard for asynchronous IOCTL dispatch, the `ZAK2333` EDID identity, and `v0.15.*` tag lineage.
- Document the Win10 runtime, driver-ranking, stacked-PR, and release-validation pitfalls in `docs/win10-release-checklist.md`.

## Why

Win10 22H2 ships an older IddCx runtime. Calling `IddCxMonitorCreate` re-entrantly from the IddCx device-control callback returns `STATUS_OPERATION_IN_PROGRESS` (`0xC0000476`), preventing the virtual monitor from being created. Older releases avoided the problem because commands arrived on a named-pipe worker thread, outside the IddCx callback stack.

The compatibility branch also retained the old `MTT1337` manufacturer spoof even though v0.17.2 uses the project-owned `ZAK2333` identity.

## Impact

- Virtual monitor creation works on Win10 22H2 while retaining synchronous completion semantics for the IOCTL caller.
- Win10 and v0.17.2 now expose the same project-owned monitor hardware ID.

## Validation

- Release x64 build completed with MSBuild and WDK `10.0.26100.6584`.
- Driver signability test and catalog generation completed without errors.
- `git diff --check` passed.
- The Win10 compatibility guard passes locally and rejects a simulated `v0.15.5` tag before its commit is merged to `win10`.
- EDID manufacturer/product bytes `68 2B 33 23` decode to `DISPLAY\ZAK2333`, matching tag `v0.17.2`.
- The Work Item version was exercised on Windows 10 Pro 22H2 build 19045: `CREATEMONITOR`, monitor arrival, `SETMODES`, re-enumeration, and a 1920x1080 shared texture all succeeded.
