### PR TITLE
Fix Win10 release tag lineage fetch

### DIFF
--- a/.github/scripts/Test-Win10Compatibility.ps1
+++ b/.github/scripts/Test-Win10Compatibility.ps1
@@ -65,7 +65,9 @@ if ($source -match 'edid\[8\]\s*=\s*0x36[\s\S]*?edid\[9\]\s*=\s*0x94[\s\S]*?edid
 }
 
 if ($env:GITHUB_REF -match '^refs/tags/v0\.15\.') {
-    & git -C $repoRoot fetch origin win10 --no-tags
+    # An explicit branch fetch may update FETCH_HEAD only. Update the remote
+    # tracking ref deterministically before checking release ancestry.
+    & git -C $repoRoot fetch origin '+refs/heads/win10:refs/remotes/origin/win10' --no-tags
     if ($LASTEXITCODE -ne 0) {
         throw 'Failed to fetch origin/win10 for release-lineage validation.'
     }


### PR DESCRIPTION
## What changed

Update the `v0.15.*` release-lineage guard with an explicit refspec so fetching `win10` deterministically refreshes `refs/remotes/origin/win10` instead of only `FETCH_HEAD`.

## Why

The first guarded `v0.15.5` release attempt was correctly stopped before tag creation, but the guard falsely rejected the already-merged release commit because its remote-tracking ref was stale.

## Validation

- Simulated `GITHUB_REF=refs/tags/v0.15.5` against the merged Win10 release commit.
- Win10 compatibility guard passed, including tag ancestry, asynchronous IOCTL dispatch, and `DISPLAY\ZAK2333` checks.
- `git diff --check` passed.
