### PR TITLE
Fix Win10 IddCx command lifetime

### DIFF
--- a/.github/scripts/Test-Win10Compatibility.ps1
+++ b/.github/scripts/Test-Win10Compatibility.ps1
@@ -27,8 +27,8 @@ $ioctlCallback = Get-SourceSection `
     -StartMarker 'VOID VirtualDisplayDriverIoDeviceControl(' `
     -EndMarker 'bool initpath()'
 
-if ($ioctlCallback -notmatch 'WdfWorkItemEnqueue\s*\(\s*workItem\s*\)') {
-    throw 'IOCTL_VDD_COMMAND must leave the IddCx callback stack through a WDF work item.'
+if ($ioctlCallback -notmatch 'WdfWorkItemEnqueue\s*\(\s*g_CommandWorkItem\s*\)') {
+    throw 'IOCTL_VDD_COMMAND must leave the IddCx callback stack through the persistent WDF work item.'
 }
 
 if ($ioctlCallback -match 'DispatchVddCommandBuffer\s*\(') {
@@ -39,8 +39,28 @@ $workItem = Get-SourceSection `
     -StartMarker 'VOID VddCommandWorkItem(WDFWORKITEM WorkItem)' `
     -EndMarker '// IddCx redirects every IRP_MJ_DEVICE_CONTROL'
 
-if ($workItem -notmatch 'DispatchVddCommandBuffer\s*\(\s*INVALID_HANDLE_VALUE\s*,\s*context->Buffer\s*\)') {
-    throw 'The WDF work item must dispatch the pending VDD command outside the IddCx callback stack.'
+if ($workItem -notmatch 'DispatchVddCommandBuffer\s*\(\s*INVALID_HANDLE_VALUE\s*,\s*writable\.data\(\)\s*\)') {
+    throw 'The WDF work item must dispatch the copied VDD command outside the IddCx callback stack.'
+}
+
+$completeIndex = $ioctlCallback.IndexOf('WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, 0)', [StringComparison]::Ordinal)
+$enqueueIndex = $ioctlCallback.IndexOf('WdfWorkItemEnqueue(g_CommandWorkItem)', [StringComparison]::Ordinal)
+if ($completeIndex -lt 0 -or $enqueueIndex -lt 0 -or $completeIndex -gt $enqueueIndex) {
+    throw 'Win10 requires the IddCx-owned IOCTL request to be completed before the monitor-command worker is enqueued.'
+}
+
+if ($workItem -match 'WdfRequestComplete') {
+    throw 'The command worker must not retain or complete the IddCx-owned IOCTL request.'
+}
+
+if ($source -notmatch 'IsAdapterReady\(\)' -or
+    $source -notmatch 'Adapter is ready for monitor commands' -or
+    $workItem -notmatch 'WaitForReadyAdapter') {
+    throw 'Monitor commands must wait for successful EvtIddCxAdapterInitFinished completion.'
+}
+
+if ($source -match 'commandWorkItemAttributes\.ExecutionLevel') {
+    throw 'Do not set ExecutionLevel on the UMDF work item; Win10 rejects it with STATUS_WDF_EXECUTION_LEVEL_INVALID.'
 }
 
 $edidIdentity = Get-SourceSection `
@@ -78,4 +98,4 @@ if ($env:GITHUB_REF -match '^refs/tags/v0\.15\.') {
     }
 }
 
-Write-Host 'Win10 compatibility invariants passed: async IOCTL dispatch and DISPLAY\ZAK2333.'
+Write-Host 'Win10 compatibility invariants passed: completed IOCTL before FIFO dispatch, adapter-ready gate, and DISPLAY\ZAK2333.'

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -42,6 +42,7 @@ Environment:
 #include <map>
 #include <set>
 #include <atomic>
+#include <deque>
 
 extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID_INIT;
 
@@ -59,6 +60,16 @@ extern "C" const GUID GUID_DEVINTERFACE_ZAKO_VDD_CONTROL = ZAKO_VDD_CONTROL_GUID
 mutex g_Mutex;
 mutex g_DataMutex; // Protects monitorModes, s_KnownMonitorModes2, numVirtualDisplays, gpuname
 WDFDEVICE g_GlobalDevice = nullptr;
+WDFWORKITEM g_CommandWorkItem = nullptr;
+
+struct QueuedVddCommand
+{
+	std::wstring buffer;
+};
+
+std::mutex g_CommandQueueMutex;
+std::deque<QueuedVddCommand> g_CommandQueue;
+bool g_CommandWorkScheduled = false;
 
 using namespace std;
 using namespace Microsoft::IndirectDisp;
@@ -2159,49 +2170,103 @@ void DispatchVddCommandBuffer(HANDLE hPipeForResponse, wchar_t *buffer)
 	}
 }
 
-// IddCx invokes EvtIddCxDeviceIoControl on its own callback stack. Calling
-// monitor-management DDIs synchronously from that stack is re-entrant: on
-// Win10 IddCxMonitorCreate rejects it with STATUS_OPERATION_IN_PROGRESS
-// (0xC0000476). Keep the WDF request pending, dispatch the command from a
-// passive work item, and complete the request only after the command finishes.
-typedef struct _VDD_COMMAND_WORKITEM_CONTEXT
-{
-	WDFREQUEST Request;
-	wchar_t Buffer[2048];
-} VDD_COMMAND_WORKITEM_CONTEXT, *PVDD_COMMAND_WORKITEM_CONTEXT;
-
-WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(VDD_COMMAND_WORKITEM_CONTEXT, VddGetCommandWorkItemContext);
-
 EVT_WDF_WORKITEM VddCommandWorkItem;
+
+static bool CommandRequiresReadyAdapter(const std::wstring &buffer)
+{
+	static constexpr const wchar_t *commands[] = {
+		L"CREATEMONITOR",
+		L"DESTROYMONITOR",
+		L"REFRESHMODES",
+		L"SETMODES"};
+
+	for (const auto *command : commands)
+	{
+		const size_t length = wcslen(command);
+		if (buffer.size() >= length && wcsncmp(buffer.c_str(), command, length) == 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool WaitForReadyAdapter(const std::wstring &buffer)
+{
+	if (!CommandRequiresReadyAdapter(buffer))
+	{
+		return true;
+	}
+
+	// EvtIddCxAdapterInitFinished can be delayed on Win10, especially after
+	// device enable/reload. Preserve FIFO ordering while waiting so a following
+	// SETMODES cannot overtake CREATEMONITOR.
+	constexpr unsigned int MaxAttempts = 600;
+	for (unsigned int attempt = 0; attempt < MaxAttempts; ++attempt)
+	{
+		WDFDEVICE device = g_GlobalDevice;
+		if (device != nullptr)
+		{
+			auto *wrapper = WdfObjectGet_IndirectDeviceContextWrapper(device);
+			if (wrapper && wrapper->pContext && wrapper->pContext->IsAdapterReady())
+			{
+				return true;
+			}
+		}
+		Sleep(50);
+	}
+
+	vddlog("e", ("Timed out waiting for adapter initialization before command: " + WStringToString(buffer)).c_str());
+	return false;
+}
 
 _Use_decl_annotations_
 VOID VddCommandWorkItem(WDFWORKITEM WorkItem)
 {
-	auto *context = VddGetCommandWorkItemContext(WorkItem);
-	NTSTATUS completionStatus = STATUS_SUCCESS;
+	UNREFERENCED_PARAMETER(WorkItem);
 
-	try
-	{
-		wstring bufferwstr(context->Buffer);
-		string bufferstr = WStringToString(bufferwstr);
-		vddlog("p", ("[IOCTL worker] " + bufferstr).c_str());
-		DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, context->Buffer);
-	}
-	catch (const std::exception &e)
-	{
-		stringstream errorStream;
-		errorStream << "Exception during asynchronous IOCTL command dispatch: " << e.what();
-		vddlog("e", errorStream.str().c_str());
-		completionStatus = STATUS_UNSUCCESSFUL;
-	}
-	catch (...)
-	{
-		vddlog("e", "Unknown exception during asynchronous IOCTL command dispatch");
-		completionStatus = STATUS_UNSUCCESSFUL;
-	}
+	// WdfWorkItemEnqueue is intentionally called only after the IOCTL request
+	// has been completed. A small deferral also guarantees that the originating
+	// EvtIddCxDeviceIoControl frame has unwound before any monitor DDI is used.
+	Sleep(10);
 
-	WdfRequestCompleteWithInformation(context->Request, completionStatus, 0);
-	WdfObjectDelete(WorkItem);
+	for (;;)
+	{
+		QueuedVddCommand command;
+		{
+			lock_guard<mutex> queueLock(g_CommandQueueMutex);
+			if (g_CommandQueue.empty())
+			{
+				g_CommandWorkScheduled = false;
+				return;
+			}
+			command = std::move(g_CommandQueue.front());
+			g_CommandQueue.pop_front();
+		}
+
+		if (!WaitForReadyAdapter(command.buffer))
+		{
+			continue;
+		}
+
+		try
+		{
+			vddlog("p", ("[IOCTL worker] " + WStringToString(command.buffer)).c_str());
+			std::vector<wchar_t> writable(command.buffer.begin(), command.buffer.end());
+			writable.push_back(L'\0');
+			DispatchVddCommandBuffer(INVALID_HANDLE_VALUE, writable.data());
+		}
+		catch (const std::exception &e)
+		{
+			stringstream errorStream;
+			errorStream << "Exception during asynchronous IOCTL command dispatch: " << e.what();
+			vddlog("e", errorStream.str().c_str());
+		}
+		catch (...)
+		{
+			vddlog("e", "Unknown exception during asynchronous IOCTL command dispatch");
+		}
+	}
 }
 
 // IddCx redirects every IRP_MJ_DEVICE_CONTROL into its own internal queue
@@ -2257,37 +2322,45 @@ VOID VirtualDisplayDriverIoDeviceControl(
 			return;
 		}
 
-		WDF_WORKITEM_CONFIG workItemConfig;
-		WDF_WORKITEM_CONFIG_INIT(&workItemConfig, VddCommandWorkItem);
-		workItemConfig.AutomaticSerialization = FALSE;
-
-		WDF_OBJECT_ATTRIBUTES workItemAttributes;
-		WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&workItemAttributes, VDD_COMMAND_WORKITEM_CONTEXT);
-		workItemAttributes.ParentObject = Device;
-
-		WDFWORKITEM workItem = nullptr;
-		status = WdfWorkItemCreate(&workItemConfig, &workItemAttributes, &workItem);
-		if (!NT_SUCCESS(status))
+		if (g_CommandWorkItem == nullptr)
 		{
-			WdfRequestComplete(Request, status);
+			WdfRequestComplete(Request, STATUS_DEVICE_NOT_READY);
 			return;
 		}
 
-		auto *workContext = VddGetCommandWorkItemContext(workItem);
-		workContext->Request = Request;
-		RtlZeroMemory(workContext->Buffer, sizeof(workContext->Buffer));
-
-		// Copy into writable, NUL-terminated work-item storage. The request's
-		// METHOD_BUFFERED memory is not accessed after this callback returns.
+		// Copy the METHOD_BUFFERED payload before completing the request. The
+		// persistent FIFO owns the command independently of request lifetime.
 		size_t copyLen = inBufferLen;
-		if (copyLen > sizeof(workContext->Buffer) - sizeof(wchar_t))
+		if (copyLen > (2048 * sizeof(wchar_t)) - sizeof(wchar_t))
 		{
-			copyLen = sizeof(workContext->Buffer) - sizeof(wchar_t);
+			copyLen = (2048 * sizeof(wchar_t)) - sizeof(wchar_t);
 		}
-		RtlCopyMemory(workContext->Buffer, pInBuffer, copyLen);
-		workContext->Buffer[copyLen / sizeof(wchar_t)] = L'\0';
+		const auto *input = static_cast<const wchar_t *>(pInBuffer);
+		std::wstring command(input, copyLen / sizeof(wchar_t));
+		if (!command.empty() && command.back() == L'\0')
+		{
+			command.pop_back();
+		}
 
-		WdfWorkItemEnqueue(workItem);
+		bool enqueueWorker = false;
+		{
+			lock_guard<mutex> queueLock(g_CommandQueueMutex);
+			g_CommandQueue.push_back({std::move(command)});
+			if (!g_CommandWorkScheduled)
+			{
+				g_CommandWorkScheduled = true;
+				enqueueWorker = true;
+			}
+		}
+
+		// Completing first is essential on Win10: while this IddCx-owned IOCTL
+		// remains pending, IddCxMonitorCreate returns
+		// STATUS_OPERATION_IN_PROGRESS (0xC0000476), even from another thread.
+		WdfRequestCompleteWithInformation(Request, STATUS_SUCCESS, 0);
+		if (enqueueWorker)
+		{
+			WdfWorkItemEnqueue(g_CommandWorkItem);
+		}
 		return;
 	}
 
@@ -2976,6 +3049,36 @@ _Use_decl_annotations_
 	// Save global reference after successful device creation
 	g_GlobalDevice = Device;
 
+	// A single passive work item drains IOCTL commands in FIFO order. It is a
+	// child of the device, so WDF waits for an active callback and destroys it
+	// automatically during device teardown.
+	WDF_WORKITEM_CONFIG commandWorkItemConfig;
+	WDF_WORKITEM_CONFIG_INIT(&commandWorkItemConfig, VddCommandWorkItem);
+	commandWorkItemConfig.AutomaticSerialization = FALSE;
+
+	WDF_OBJECT_ATTRIBUTES commandWorkItemAttributes;
+	WDF_OBJECT_ATTRIBUTES_INIT(&commandWorkItemAttributes);
+	commandWorkItemAttributes.ParentObject = Device;
+	// Work-item callbacks already run at PASSIVE_LEVEL. UMDF rejects an
+	// explicit ExecutionLevel on a WDFWORKITEM with
+	// STATUS_WDF_EXECUTION_LEVEL_INVALID (0xC0200211) on Windows 10.
+
+	{
+		lock_guard<mutex> queueLock(g_CommandQueueMutex);
+		g_CommandQueue.clear();
+		g_CommandWorkScheduled = false;
+	}
+	g_CommandWorkItem = nullptr;
+	Status = WdfWorkItemCreate(&commandWorkItemConfig, &commandWorkItemAttributes, &g_CommandWorkItem);
+	if (!NT_SUCCESS(Status))
+	{
+		logStream.str("");
+		logStream << "Failed to create command work item. Status: 0x" << std::hex << Status;
+		vddlog("e", logStream.str().c_str());
+		g_GlobalDevice = nullptr;
+		return Status;
+	}
+
 	return Status;
 }
 
@@ -3051,6 +3154,7 @@ _Use_decl_annotations_
 	auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
 	if (pContext && pContext->pContext)
 	{
+		pContext->pContext->MarkAdapterNotReady();
 		logStream.str("");
 		logStream << "Preparing device for low-power state...";
 		vddlog("d", logStream.str().c_str());
@@ -4531,6 +4635,7 @@ IndirectDeviceContext::~IndirectDeviceContext()
 void IndirectDeviceContext::InitAdapter()
 {
 	stringstream logStream;
+	m_AdapterReady.store(false, std::memory_order_release);
 
 	// Load settings and GPU configuration first
 	loadSettings();
@@ -4713,7 +4818,9 @@ void IndirectDeviceContext::InitAdapter()
 void IndirectDeviceContext::FinishInit()
 {
 	Options.Adapter.apply(m_Adapter);
+	m_AdapterReady.store(true, std::memory_order_release);
 	vddlog("i", "Applied Adapter configs.");
+	vddlog("i", "Adapter is ready for monitor commands.");
 }
 
 void IndirectDeviceContext::CreateMonitor(unsigned int index, const GUID *pClientGuid, float maxNits, float minNits, float maxFALL, float widthCm, float heightCm)

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <set>
 #include <mutex>
+#include <atomic>
 
 #include "Trace.h"
 
@@ -101,6 +102,8 @@ namespace Microsoft
 
             void InitAdapter();
             void FinishInit();
+            bool IsAdapterReady() const noexcept { return m_AdapterReady.load(std::memory_order_acquire); }
+            void MarkAdapterNotReady() noexcept { m_AdapterReady.store(false, std::memory_order_release); }
 
             void CreateMonitor(unsigned int index, const GUID* pClientGuid = nullptr, float maxNits = 1000.0f, float minNits = 0.0001f, float maxFALL = 0.0f, float widthCm = 0.0f, float heightCm = 0.0f);
             bool DestroyMonitor(unsigned int index);
@@ -159,6 +162,10 @@ namespace Microsoft
 
             WDFDEVICE m_WdfDevice;
             IDDCX_ADAPTER m_Adapter;
+            // IddCx adapters are initialized in two stages. The adapter handle
+            // returned by IddCxAdapterInitAsync must not host monitors until
+            // EvtIddCxAdapterInitFinished reports success.
+            std::atomic_bool m_AdapterReady{false};
             // Protects m_Monitors, m_MonitorCreationParams, m_ArrivedMonitors,
             // m_ProcessingThreads and m_MouseEvents
             mutable std::recursive_mutex m_monitorsMutex;

--- a/docs/win10-release-checklist.md
+++ b/docs/win10-release-checklist.md
@@ -14,7 +14,11 @@ The driver compiled with a current WDK, but Windows 10 22H2 loaded IddCx 1.5.1. 
 
 ### Changing the control transport changed the callback context
 
-`v0.14.3` handled commands on a named-pipe worker thread. The `v0.15.x` IOCTL transport initially dispatched monitor commands inline from `EvtIddCxDeviceIoControl`. Calling `IddCxMonitorCreate` on that IddCx callback stack returned `STATUS_OPERATION_IN_PROGRESS` on Win10. VDD commands must be dispatched from the WDF work item and the request completed after that worker finishes.
+`v0.14.3` handled commands on a named-pipe worker thread. The `v0.15.x` IOCTL transport initially dispatched monitor commands inline from `EvtIddCxDeviceIoControl`. Calling `IddCxMonitorCreate` on that IddCx callback stack returned `STATUS_OPERATION_IN_PROGRESS` on Win10.
+
+The first attempted fix moved dispatch to a WDF work item but kept the IddCx-owned IOCTL request pending until the worker finished. That changed the thread, not the IddCx operation lifetime, and the exact `v0.15.5` CI package still returned `0xC0000476`. The corrected path copies the command into a persistent FIFO, completes the IOCTL request first, and only then enqueues the passive worker. Monitor-management commands additionally wait until `EvtIddCxAdapterInitFinished` has reported success.
+
+Do not explicitly set `ExecutionLevel` on the UMDF work-item object. Its callback is already passive; Win10 rejects that object attribute with `STATUS_WDF_EXECUTION_LEVEL_INVALID` (`0xC0200211`) and leaves the adapter at Device Manager Code 31.
 
 ### Display name and hardware ID are separate EDID fields
 
@@ -35,7 +39,11 @@ PR builds use the standard `pull_request` event and never receive the production
 `.github/scripts/Test-Win10Compatibility.ps1` runs for `win10`, PRs targeting `win10`, and `v0.15.*` tags. It rejects these known regressions:
 
 - inline command dispatch from `VirtualDisplayDriverIoDeviceControl`;
-- removal of the WDF work-item dispatch path;
+- removal of the FIFO WDF work-item dispatch path;
+- enqueuing monitor work before completing the IddCx-owned IOCTL request;
+- retaining/completing the IOCTL request from the worker;
+- removal of the adapter-ready gate;
+- an explicit execution level on the UMDF work item;
 - restoration of the `DISPLAY\MTT1337` EDID bytes;
 - a `v0.15.*` tag whose commit is not contained in `origin/win10`.
 


### PR DESCRIPTION
## What changed

- Copy each IOCTL command into a driver-owned FIFO.
- Complete the IddCx-owned IOCTL request before enqueueing monitor work.
- Drain commands from one persistent WDF work item so FIFO order is preserved.
- Gate monitor-management commands on successful `EvtIddCxAdapterInitFinished`.
- Do not set `ExecutionLevel` on the UMDF work item; its callback is already passive.
- Extend the Win10 CI guard and release checklist with the exact regressions found during VM validation.

## Root cause

PR #31 moved monitor creation to another thread, but kept the IddCx-owned IOCTL request pending until the worker completed. That changed the thread without ending the IddCx operation lifetime. On Win10 22H2, `IddCxMonitorCreate` therefore still returned `STATUS_OPERATION_IN_PROGRESS` (`0xC0000476`).

The first persistent-worker implementation also set `WDF_OBJECT_ATTRIBUTES.ExecutionLevel`. Win10 UMDF rejects that attribute for a work-item object with `STATUS_WDF_EXECUTION_LEVEL_INVALID` (`0xC0200211`), leaving the adapter at Device Manager Code 31.

## Impact

Win10 22H2 can create and re-enumerate the virtual monitor through the IOCTL transport. The monitor continues to enumerate with the project-owned `DISPLAY\ZAK2333` identity.

Related reports:

- [AlkaidLab/foundation-sunshine#612](https://github.com/AlkaidLab/foundation-sunshine/issues/612)
- [AlkaidLab/foundation-sunshine#907](https://github.com/AlkaidLab/foundation-sunshine/issues/907)
- Supersedes the incomplete runtime fix in #31 and release `v0.15.5`.

## Validation

- Release x64 build completed with MSBuild and WDK `10.0.26100.6584`.
- ApiValidator, Inf2Cat, catalog generation, and test signing passed with 0 errors.
- Win10 compatibility invariant script passed.
- Tested on Windows 10 Pro 22H2 build 19045 with IddCx `0x1501`.
- Verified the installed UMDF DLL SHA-256 matched the tested package: `CB0D7D7A3D40E19E563FB8FDD9F12192761E2C31DE21F0A24BFEED4B716D7529`.
- Device Manager reported the adapter started with Code 0.
- `CREATEMONITOR` enumerated `DISPLAY\ZAK2333`.
- `SETMODES 1920x1080x60,2560x1440x60` re-enumerated one monitor.
- Windows reported the virtual monitor active at 1920x1080.
- Driver logs confirmed adapter readiness, FIFO worker dispatch, monitor creation, arrival, mode re-enumeration, and shared-texture setup.
