### PR TITLE
fix(win10): restore Sunshine IOCTL control

### DIFF
--- a/.github/scripts/Test-Win10Compatibility.ps1
+++ b/.github/scripts/Test-Win10Compatibility.ps1
@@ -28,7 +28,7 @@ $ioctlCallback = Get-SourceSection `
     -EndMarker 'bool initpath()'
 
 if ($ioctlCallback -notmatch 'WdfWorkItemEnqueue\s*\(\s*g_CommandWorkItem\s*\)') {
-    throw 'The Win11 IOCTL_VDD_COMMAND path must leave the IddCx callback stack through the persistent WDF work item.'
+    throw 'The IOCTL_VDD_COMMAND path must leave the IddCx callback stack through the persistent WDF work item.'
 }
 
 if ($ioctlCallback -match 'DispatchVddCommandBuffer\s*\(') {
@@ -59,28 +59,27 @@ if ($source -notmatch 'IsAdapterReady\(\)' -or
     throw 'Monitor commands must wait for successful EvtIddCxAdapterInitFinished completion.'
 }
 
-# Win10 22H2 ships the down-level IddCx 1.5.1 host. Registering the optional
-# custom device-control callback prevents that host from delivering
-# EvtIddCxAdapterInitFinished. Keep the last known-good named-pipe surface on
-# Win10 while retaining the IOCTL transport on Win11.
+# Sunshine uses the IOCTL control surface on both Win10 and Win11. Earlier
+# diagnostics incorrectly attributed Win10 monitor-enumeration failure to the
+# callback; the isolated cause was the legacy 99.x/100.x DriverVer range.
 if ($source -notmatch 'g_IsWin10OrOlder\.store\s*\(\s*DetectWin10OrOlderHost\(\)\s*\)') {
-    throw 'DriverEntry must resolve the Win10/Win11 transport before device creation.'
+    throw 'DriverEntry must resolve the host version before device creation.'
 }
 
-if ($source -notmatch 'if\s*\(\s*!g_IsWin10OrOlder\.load\(\)\s*\)\s*\{\s*IddConfig\.EvtIddCxDeviceIoControl\s*=\s*VirtualDisplayDriverIoDeviceControl') {
-    throw 'EvtIddCxDeviceIoControl must only be registered on Win11.'
+if ($source -notmatch 'IddConfig\.EvtIddCxDeviceIoControl\s*=\s*VirtualDisplayDriverIoDeviceControl') {
+    throw 'EvtIddCxDeviceIoControl must be registered on every supported Windows version.'
 }
 
 $deviceAdd = Get-SourceSection `
     -StartMarker 'VirtualDisplayDriverDeviceAdd(WDFDRIVER Driver' `
     -EndMarker 'VirtualDisplayDriverDeviceD0Entry(WDFDEVICE Device'
 
-if ($deviceAdd -notmatch 'if\s*\(\s*!g_IsWin10OrOlder\.load\(\)\s*\)[\s\S]*?WdfDeviceCreateDeviceInterface') {
-    throw 'The custom control device interface must only be created on Win11.'
+if ($deviceAdd -notmatch 'WdfDeviceCreateDeviceInterface\s*\(\s*Device\s*,\s*&GUID_DEVINTERFACE_ZAKO_VDD_CONTROL') {
+    throw 'The custom IOCTL control device interface must be created on every supported Windows version.'
 }
 
-if ($deviceAdd -notmatch 'if\s*\(\s*g_IsWin10OrOlder\.load\(\)\s*\)\s*\{[\s\S]*?return STATUS_SUCCESS;[\s\S]*?WdfWorkItemCreate') {
-    throw 'Win10 must return before creating the IOCTL command work item.'
+if ($deviceAdd -notmatch 'WdfWorkItemCreate\s*\(') {
+    throw 'The persistent IOCTL command work item must be created on every supported Windows version.'
 }
 
 $pipeServer = Get-SourceSection `
@@ -92,8 +91,8 @@ if ($pipeServer -notmatch 'CreateNamedPipeW\s*\(' -or
     throw 'Win10 compatibility commands must use the shared parser through ZakoVDDPipe.'
 }
 
-if ($source -notmatch 'if\s*\(\s*g_IsWin10OrOlder\.load\(\)\s*\)\s*\{\s*StartWin10NamedPipeServer\(\)') {
-    throw 'DriverEntry must start the named pipe on Win10.'
+if ($source -match 'if\s*\(\s*g_IsWin10OrOlder\.load\(\)\s*\)\s*\{\s*StartWin10NamedPipeServer\(\)') {
+    throw 'Sunshine-supported Win10 builds must not select the named-pipe transport instead of IOCTL.'
 }
 
 if ($source -notmatch 'StopWin10NamedPipeServer\(\)') {
@@ -159,4 +158,4 @@ if ($env:GITHUB_REF -match '^refs/tags/v0\.15\.') {
     }
 }
 
-Write-Host 'Compatibility invariants passed: Win10 pipe/legacy IddCx surface, Win11 deferred IOCTL path, single adapter registration across D3, and DISPLAY\ZAK2333.'
+Write-Host 'Compatibility invariants passed: Win10/Win11 deferred IOCTL path, down-level IddCx adapter surface, single adapter registration across D3, and DISPLAY\ZAK2333.'

--- a/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
+++ b/Virtual Display Driver (HDR)/ZakoVDD/Driver.cpp
@@ -2667,11 +2667,6 @@ _Use_decl_annotations_ extern "C" NTSTATUS DriverEntry(
 	{
 		return Status;
 	}
-	if (g_IsWin10OrOlder.load())
-	{
-		StartWin10NamedPipeServer();
-	}
-
 	return Status;
 }
 
@@ -3016,12 +3011,10 @@ _Use_decl_annotations_
 			  << "\n  EvtIddCxMonitorUnassignSwapChain: " << (IddConfig.EvtIddCxMonitorUnassignSwapChain ? "Set" : "Not Set");
 	vddlog("d", logStream.str().c_str());
 
-	// The down-level IddCx 1.5.1 host on Win10 stalls adapter initialization
-	// when this optional callback is present. Win10 uses the compatibility pipe.
-	if (!g_IsWin10OrOlder.load())
-	{
-		IddConfig.EvtIddCxDeviceIoControl = VirtualDisplayDriverIoDeviceControl;
-	}
+	// Sunshine uses this IOCTL transport on every supported Windows version.
+	// Earlier Win10 diagnostics incorrectly blamed this callback for an
+	// enumeration failure that was subsequently isolated to DriverVer.
+	IddConfig.EvtIddCxDeviceIoControl = VirtualDisplayDriverIoDeviceControl;
 
 	IddConfig.EvtIddCxAdapterInitFinished = VirtualDisplayDriverAdapterInitFinished;
 
@@ -3145,18 +3138,15 @@ _Use_decl_annotations_
 		return Status;
 	}
 
-	if (!g_IsWin10OrOlder.load())
+	Status = WdfDeviceCreateDeviceInterface(Device, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, NULL);
+	if (!NT_SUCCESS(Status))
 	{
-		Status = WdfDeviceCreateDeviceInterface(Device, &GUID_DEVINTERFACE_ZAKO_VDD_CONTROL, NULL);
-		if (!NT_SUCCESS(Status))
-		{
-			logStream.str("");
-			logStream << "WdfDeviceCreateDeviceInterface failed with status: " << Status;
-			vddlog("e", logStream.str().c_str());
-			return Status;
-		}
-		vddlog("d", "Registered Zako VDD control device interface");
+		logStream.str("");
+		logStream << "WdfDeviceCreateDeviceInterface failed with status: " << Status;
+		vddlog("e", logStream.str().c_str());
+		return Status;
 	}
+	vddlog("d", "Registered Zako VDD control device interface");
 
 	// Create a new device context object and attach it to the WDF device object
 	/*
@@ -3183,11 +3173,6 @@ _Use_decl_annotations_
 
 	// Save global reference after successful device creation
 	g_GlobalDevice = Device;
-	if (g_IsWin10OrOlder.load())
-	{
-		vddlog("i", "Win10 compatibility path: skipping IOCTL command work item.");
-		return STATUS_SUCCESS;
-	}
 
 	// A single passive work item drains IOCTL commands in FIFO order. It is a
 	// child of the device, so WDF waits for an active callback and destroys it


### PR DESCRIPTION
Restore the IOCTL control interface on Windows 10 so Sunshine uses the same transport on Win10 and Win11.

The earlier named-pipe fallback was based on diagnostics that were confounded by the `99.x`/`100.x` `DriverVer` regression. Once the safe `15.x` version policy is retained, the down-level Win10 22H2 IddCx host works with the IOCTL callback, device interface, and deferred command work item.

CI invariants now require every supported Windows version to:

- register `EvtIddCxDeviceIoControl`;
- publish `GUID_DEVINTERFACE_ZAKO_VDD_CONTROL`;
- create the persistent asynchronous IOCTL command work item;
- never select the Win10 named-pipe fallback in `DriverEntry`.

Win10 22H2 runtime validation of the exact PR artifact:

- OS: Windows 10 build 19045;
- driver version: `15.0.0.179`;
- package and active DLL SHA-256: `A4A2C6D49D37A1F830E1391D60EB5086C1A0B682F520896A1C9A04DF135CF167`;
- interface enumerated as `\\?\root#display#0000#{da9f8c2b-7e4f-49a1-9d4e-6f2b0e1a0c4d}`;
- `IOCTL_VDD_PING`: passed;
- `IOCTL_VDD_COMMAND(CREATEMONITOR)`: passed;
- `DISPLAY\ZAK2333`: Config Manager error code 0.

Relates to AlkaidLab/foundation-sunshine#907
Relates to AlkaidLab/foundation-sunshine#612
