### PR TITLE
fix(power): defer swap-chain teardown to IddCx

### DIFF
--- a/ZakoVDD/Device/WdfDeviceLifecycle.cpp
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.cpp
@@ -88,8 +88,9 @@ _Use_decl_annotations_
 	VDD_LOG_DEBUG_STREAM("Initializing device:"
 	                     << "\n  DeviceInit Pointer: " << static_cast<void *>(pDeviceInit));
 
-	// Keep the WDF power callbacks lightweight. D0Exit is diagnostic only;
-	// IddCx owns swap-chain teardown through EvtIddCxMonitorUnassignSwapChain.
+	// Keep the WDF power callbacks lightweight. D0Exit is diagnostic only.
+	// IddCx coordinates invalidation through EvtIddCxMonitorUnassignSwapChain;
+	// the driver-owned processor then releases its assigned swap-chain object.
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&PnpPowerCallbacks);
 	PnpPowerCallbacks.EvtDeviceD0Entry = VirtualDisplayDriverDeviceD0Entry;
 	PnpPowerCallbacks.EvtDeviceD0Exit = VirtualDisplayDriverDeviceD0Exit;
@@ -288,8 +289,9 @@ _Use_decl_annotations_
 
 		VDD_LOG_DEBUG("InitAdapter called successfully.");
 
-		// Swap-chain ownership remains with IddCx. If a new swap chain is needed
-		// after D3, it will arrive through EvtIddCxMonitorAssignSwapChain.
+		// Only IddCx can provide the swap-chain handle, render adapter and frame
+		// event required to create a processor. If the active display needs a new
+		// swap chain after D3, IddCx supplies it through AssignSwapChain.
 	}
 	else
 	{
@@ -304,12 +306,13 @@ _Use_decl_annotations_
 	NTSTATUS
 	VirtualDisplayDriverDeviceD0Exit(WDFDEVICE Device, WDF_POWER_DEVICE_STATE TargetState)
 {
-	// Do not tear down swap chains here. IddCx reports invalid swap chains through
-	// EvtIddCxMonitorUnassignSwapChain; this callback only records power ordering.
+	// Do not stop or release swap chains from this power callback. IddCx reports
+	// invalidation through EvtIddCxMonitorUnassignSwapChain; that path stops the
+	// processor and its worker releases the driver-owned swap-chain object.
 	VDD_LOG_DEBUG_STREAM("Exiting D0 power state:"
 	                     << "\n  Device Handle: " << static_cast<void *>(Device)
 	                     << "\n  Target State: " << TargetState
-	                     << "\n  SwapChain teardown: delegated to IddCx");
+	                     << "\n  SwapChain power handling: coordinated by IddCx callbacks");
 
 	return STATUS_SUCCESS;
 }

--- a/ZakoVDD/Device/WdfDeviceLifecycle.cpp
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.cpp
@@ -88,9 +88,11 @@ _Use_decl_annotations_
 	VDD_LOG_DEBUG_STREAM("Initializing device:"
 	                     << "\n  DeviceInit Pointer: " << static_cast<void *>(pDeviceInit));
 
-	// Register for power callbacks - D0Entry for power-on, D0Exit for power-off (IDDCX 1.10 power management)
+	// Keep the WDF power callbacks lightweight. D0Exit is diagnostic only;
+	// IddCx owns swap-chain teardown through EvtIddCxMonitorUnassignSwapChain.
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&PnpPowerCallbacks);
 	PnpPowerCallbacks.EvtDeviceD0Entry = VirtualDisplayDriverDeviceD0Entry;
+	PnpPowerCallbacks.EvtDeviceD0Exit = VirtualDisplayDriverDeviceD0Exit;
 	WdfDeviceInitSetPnpPowerEventCallbacks(pDeviceInit, &PnpPowerCallbacks);
 
 	IDD_CX_CLIENT_CONFIG IddConfig;
@@ -286,14 +288,28 @@ _Use_decl_annotations_
 
 		VDD_LOG_DEBUG("InitAdapter called successfully.");
 
-		// Note: When recovering from D3, the system will automatically re-assign SwapChain
-		// through the EvtIddCxMonitorAssignSwapChain callback, so we don't need to do it here.
+		// Swap-chain ownership remains with IddCx. If a new swap chain is needed
+		// after D3, it will arrive through EvtIddCxMonitorAssignSwapChain.
 	}
 	else
 	{
 		VDD_LOG_ERROR("Failed to get device context.");
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
+
+	return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+	NTSTATUS
+	VirtualDisplayDriverDeviceD0Exit(WDFDEVICE Device, WDF_POWER_DEVICE_STATE TargetState)
+{
+	// Do not tear down swap chains here. IddCx reports invalid swap chains through
+	// EvtIddCxMonitorUnassignSwapChain; this callback only records power ordering.
+	VDD_LOG_DEBUG_STREAM("Exiting D0 power state:"
+	                     << "\n  Device Handle: " << static_cast<void *>(Device)
+	                     << "\n  Target State: " << TargetState
+	                     << "\n  SwapChain teardown: delegated to IddCx");
 
 	return STATUS_SUCCESS;
 }

--- a/ZakoVDD/Device/WdfDeviceLifecycle.cpp
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.cpp
@@ -91,7 +91,6 @@ _Use_decl_annotations_
 	// Register for power callbacks - D0Entry for power-on, D0Exit for power-off (IDDCX 1.10 power management)
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&PnpPowerCallbacks);
 	PnpPowerCallbacks.EvtDeviceD0Entry = VirtualDisplayDriverDeviceD0Entry;
-	PnpPowerCallbacks.EvtDeviceD0Exit = VirtualDisplayDriverDeviceD0Exit;
 	WdfDeviceInitSetPnpPowerEventCallbacks(pDeviceInit, &PnpPowerCallbacks);
 
 	IDD_CX_CLIENT_CONFIG IddConfig;
@@ -294,61 +293,6 @@ _Use_decl_annotations_
 	{
 		VDD_LOG_ERROR("Failed to get device context.");
 		return STATUS_INSUFFICIENT_RESOURCES;
-	}
-
-	return STATUS_SUCCESS;
-}
-
-_Use_decl_annotations_
-	NTSTATUS
-	VirtualDisplayDriverDeviceD0Exit(WDFDEVICE Device, WDF_POWER_DEVICE_STATE TargetState)
-{
-	// Log the exit from D0 state
-	VDD_LOG_DEBUG_STREAM("Exiting D0 power state:"
-	                     << "\n  Device Handle: " << static_cast<void *>(Device)
-	                     << "\n  Target State: " << TargetState);
-
-	// This function is called by WDF when the device is transitioning to a low-power state (D3).
-	// For IDDCX 1.10 power management, we should pause SwapChain processing to save resources.
-
-	auto *pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
-	if (pContext && pContext->pContext)
-	{
-		VDD_LOG_DEBUG("Preparing device for low-power state...");
-
-		// Stop SwapChain processing to save GPU/CPU resources during low-power state
-		if (pContext->pContext->HasActiveSwapChain())
-		{
-			VDD_LOG_INFO("Pausing SwapChain processing for power management");
-
-			try
-			{
-				// Unassign all swap chains to stop processing
-				pContext->pContext->UnassignAllSwapChains();
-				Sleep(50);
-
-				VDD_LOG_DEBUG("SwapChain processing paused successfully for power management");
-			}
-			catch (const std::exception &e)
-			{
-				VDD_LOG_ERROR_STREAM("Exception while pausing SwapChain for power management: " << e.what());
-			}
-			catch (...)
-			{
-				VDD_LOG_ERROR("Unknown exception while pausing SwapChain for power management");
-			}
-		}
-		else
-		{
-			VDD_LOG_DEBUG("No active SwapChain to pause");
-		}
-
-		VDD_LOG_DEBUG("Device prepared for low-power state");
-	}
-	else
-	{
-		VDD_LOG_WARNING("Failed to get device context during D0Exit");
-		// Don't return error - allow power transition to continue
 	}
 
 	return STATUS_SUCCESS;

--- a/ZakoVDD/Device/WdfDeviceLifecycle.h
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.h
@@ -6,3 +6,4 @@ extern "C" EVT_WDF_DRIVER_UNLOAD EvtDriverUnload;
 
 EVT_WDF_DRIVER_DEVICE_ADD VirtualDisplayDriverDeviceAdd;
 EVT_WDF_DEVICE_D0_ENTRY VirtualDisplayDriverDeviceD0Entry;
+EVT_WDF_DEVICE_D0_EXIT VirtualDisplayDriverDeviceD0Exit;

--- a/ZakoVDD/Device/WdfDeviceLifecycle.h
+++ b/ZakoVDD/Device/WdfDeviceLifecycle.h
@@ -6,4 +6,3 @@ extern "C" EVT_WDF_DRIVER_UNLOAD EvtDriverUnload;
 
 EVT_WDF_DRIVER_DEVICE_ADD VirtualDisplayDriverDeviceAdd;
 EVT_WDF_DEVICE_D0_ENTRY VirtualDisplayDriverDeviceD0Entry;
-EVT_WDF_DEVICE_D0_EXIT VirtualDisplayDriverDeviceD0Exit;


### PR DESCRIPTION
## 说明

ZakoVDD 在 UMDF 的 D0Exit 回调中主动销毁全部 SwapChain processor。该路径与 IddCx 已有的 EvtIddCxMonitorUnassignSwapChain 生命周期重复，并可能让关键电源回调等待线程退出，最终触发 UMDF 的主机超时。

## 修改

- 不再注册自定义 D0Exit 清理回调。
- 由 IddCx 的 UnassignSwapChain 回调负责停止并释放对应 SwapChain processor。

Relates to AlkaidLab/foundation-sunshine#508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **稳定性改进**
  - 优化设备进入低功耗状态时的处理流程，减少不必要的显示链路操作。
  - 调整显示交换链的清理时机，使其在显示器取消关联时完成，提升虚拟显示设备在电源状态切换期间的稳定性。
- **日志**
  - 保留电源状态转换日志，便于诊断设备电源行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->